### PR TITLE
Add @types/async-lock to resolve missing module typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.7",
+    "@types/async-lock": "^1.1.3",
     "@types/react-native": "^0.62.2",
     "async-lock": "^1.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,6 +208,11 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
+"@types/async-lock@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/async-lock/-/async-lock-1.1.3.tgz#0d86017cf87abbcb941c55360e533d37a3f23b3d"
+  integrity sha512-UpeDcjGKsYEQMeqEbfESm8OWJI305I7b9KE4ji3aBjoKWyN5CTdn8izcA1FM1DVDne30R5fNEnIy89vZw5LXJQ==
+
 "@types/prop-types@*":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"


### PR DESCRIPTION
## Description of the change

When running a type check with this package installed, it throws type errors since the TS source isnt built to CommonJS. I temporarily fixed the type error, but the package should be distributed with commonJS.

Example of build set up for commonJS: https://github.com/callstack/react-native-builder-bob

Quick workaround for https://github.com/rudderlabs/rudder-sdk-react-native/issues/74

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
