### PR TITLE
[BugFix] react-native package old peer dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rudderstack/rudder-sdk-react-native",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Rudder React Native SDK",
   "main": "index.ts",
   "keywords": [
@@ -14,7 +14,7 @@
     "prettier": "^1.14.2"
   },
   "peerDependencies": {
-    "react-native": "0.41.2"
+    "react-native": ">=0.41.2 <=0.67.2"
   },
   "dependencies": {
     "@babel/runtime": "^7.7.7",

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -9,4 +9,4 @@ export const CONFIG_REFRESH_INTERVAL = 2;
 export const TRACK_LIFECYCLE_EVENTS = true;
 export const RECORD_SCREEN_VIEWS = false;
 export const LOG_LEVEL = RUDDER_LOG_LEVEL.ERROR;
-export const SDK_VERSION = "1.1.1";
+export const SDK_VERSION = "1.1.2";


### PR DESCRIPTION
## Description of the change

Updated Peer Dependency of react-native package to '>=0.41.2 <=0.67.2'

[Notion Link](https://www.notion.so/rudderstacks/RN-SDK-Peer-Dependencies-Update-cb9a0fb0b3db4741aa695d4a28fb71a1)


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#85 ]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer.
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
