### PR TITLE
fix: add proguard for third party integration due to minifyEnabled true

### DIFF
--- a/integrations/rudder-integration-amplitude-react-native/README.md
+++ b/integrations/rudder-integration-amplitude-react-native/README.md
@@ -17,4 +17,25 @@ Run `pod install` inside the `ios` directory of your project adding `@rudderstac
 import RudderIntegrationAppcenterReactNative from '@rudderstack/rudder-integration-amplitude-react-native';
 ```
 
+## Extra Step for minifyEnabled 
 
+if you are using `minifyEnabled true` then you will have to use proguard
+
+```
+ buildTypes {
+        debug {
+           ...
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+           
+        }
+    }
+```
+
+
+then you will have to use proguard `android/app/proguard-rules.pro`
+```
+-keep class com.rudderstack.android.integrations.amplitude.** { *; }
+```

--- a/integrations/rudder-integration-appcenter-react-native/README.md
+++ b/integrations/rudder-integration-appcenter-react-native/README.md
@@ -24,4 +24,25 @@ import RudderIntegrationAppcenterReactNative from '@rudderstack/rudder-integrati
 RudderIntegrationAppcenterReactNative;
 ```
 
+## Extra Step for minifyEnabled 
 
+if you are using `minifyEnabled true` then you will have to use proguard
+
+```
+ buildTypes {
+        debug {
+           ...
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+           
+        }
+    }
+```
+
+
+then you will have to use proguard `android/app/proguard-rules.pro`
+```
+-keep class com.rudderstack.android.integrations.appcenter.** { *; }
+```

--- a/integrations/rudder-integration-appsflyer-react-native/README.md
+++ b/integrations/rudder-integration-appsflyer-react-native/README.md
@@ -15,3 +15,26 @@ import RudderIntegrationAppsflyerReactNative from '@rudderstack/rudder-integrati
 // TODO: What to do with the module?
 RudderIntegrationAppsflyerReactNative;
 ```
+
+## Extra Step for minifyEnabled 
+
+if you are using `minifyEnabled true` then you will have to use proguard
+
+```
+ buildTypes {
+        debug {
+           ...
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+           
+        }
+    }
+```
+
+
+then you will have to use proguard `android/app/proguard-rules.pro`
+```
+-keep class com.rudderstack.android.integrations.appsflyer.** { *; }
+```

--- a/integrations/rudder-integration-braze-react-native/README.md
+++ b/integrations/rudder-integration-braze-react-native/README.md
@@ -18,3 +18,25 @@ import RudderIntegrationAppcenterReactNative from '@rudderstack/rudder-integrati
 ```
 
 
+## Extra Step for minifyEnabled 
+
+if you are using `minifyEnabled true` then you will have to use proguard
+
+```
+ buildTypes {
+        debug {
+           ...
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+           
+        }
+    }
+```
+
+
+then you will have to use proguard `android/app/proguard-rules.pro`
+```
+-keep com.rudderstack.android.integration.braze.** { *; }
+```

--- a/integrations/rudder-integration-clevertap-react-native/README.md
+++ b/integrations/rudder-integration-clevertap-react-native/README.md
@@ -15,3 +15,26 @@ import RudderIntegrationCleverTapReactNative from '@rudderstack/rudder-integrati
 // TODO: What to do with the module?
 RudderIntegrationCleverTapReactNative;
 ```
+
+## Extra Step for minifyEnabled 
+
+if you are using `minifyEnabled true` then you will have to use proguard
+
+```
+ buildTypes {
+        debug {
+           ...
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+           
+        }
+    }
+```
+
+
+then you will have to use proguard `android/app/proguard-rules.pro`
+```
+-keep class com.rudderstack.android.integrations.clevertap.** { *; }
+```

--- a/integrations/rudder-integration-firebase-react-native/README.md
+++ b/integrations/rudder-integration-firebase-react-native/README.md
@@ -15,3 +15,26 @@ import RudderIntegrationFirebaseReactNative from '@rudderstack/rudder-integratio
 // TODO: What to do with the module?
 RudderIntegrationFirebaseReactNative;
 ```
+
+## Extra Step for minifyEnabled 
+
+if you are using `minifyEnabled true` then you will have to use proguard
+
+```
+ buildTypes {
+        debug {
+           ...
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+           
+        }
+    }
+```
+
+
+then you will have to use proguard `android/app/proguard-rules.pro`
+```
+-keep com.rudderstack.android.integration.firebase.** { *; }
+```

--- a/integrations/rudder-integration-moengage-react-native/README.md
+++ b/integrations/rudder-integration-moengage-react-native/README.md
@@ -18,3 +18,25 @@ import RudderIntegrationAppcenterReactNative from '@rudderstack/rudder-integrati
 ```
 
 
+## Extra Step for minifyEnabled 
+
+if you are using `minifyEnabled true` then you will have to use proguard
+
+```
+ buildTypes {
+        debug {
+           ...
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+           
+        }
+    }
+```
+
+
+then you will have to use proguard `android/app/proguard-rules.pro`
+```
+-keep com.rudderstack.android.integrations.moengage.** { *; }
+```

--- a/integrations/rudder-integration-singular-react-native/README.md
+++ b/integrations/rudder-integration-singular-react-native/README.md
@@ -18,3 +18,25 @@ import RudderIntegrationSingularReactNative from '@rudderstack/rudder-integratio
 ```
 
 
+## Extra Step for minifyEnabled 
+
+if you are using `minifyEnabled true` then you will have to use proguard
+
+```
+ buildTypes {
+        debug {
+           ...
+        }
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+           
+        }
+    }
+```
+
+
+then you will have to use proguard `android/app/proguard-rules.pro`
+```
+-keep com.rudderstack.android.integration.singular.** { *; }
+```


### PR DESCRIPTION
## Description of the change

> Description here
when the user enables minifyEnabled true than `gson` unable to parse JSON, so we need to add that file in proguard

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

I got this error minifyEnabled true, you can check this issue, it is due to gson https://github.com/google/gson/issues/1632 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
