### PR TITLE
fix: compatible with rn.

### DIFF
--- a/RNRudderSdk.podspec
+++ b/RNRudderSdk.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "Rudder", ">= 1.6.0"
+  s.dependency "Rudder", "1.6.0"
 end
 
 


### PR DESCRIPTION
## Description of the change

> fixed Rudder iOS SDK version.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
![image](https://user-images.githubusercontent.com/37520667/169939692-1279750e-5926-4e69-beca-7ceeae843a16.png)

Rudder iOS SDK latest version upgrade to [v2.0.1](https://github.com/rudderlabs/rudder-sdk-ios/releases/tag/v2.0.1), but now v1 rn-sdk not compatible now. 

So we have 2 options: 

- fixed Rudder iOS SDK version to `v1.6`.
- upgrade rn-SDK. ( I'm not sure how long it will take you to finish, but currently affects everyone who uses the repo, unless you won't reinstall)




## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
