### PR TITLE
Have the peer dep of RN use any version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prettier": "^1.14.2"
   },
   "peerDependencies": {
-    "react-native": ">=0.41.2 <=0.67.2"
+    "react-native": "*"
   },
   "dependencies": {
     "@babel/runtime": "^7.7.7",


### PR DESCRIPTION
## Description of the change
The peer dependency of the library restricts its use with newer versions of RN but in fact it works without issues.

By setting the peer dependency as any this will allow npm to resolve without complaining removing the need to use the --force flag

```
npm ERR! Found: react-native@0.68.2
npm ERR! node_modules/react-native
npm ERR!   react-native@"0.68.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react-native@">=0.41.2 <=0.67.2" from @rudderstack/rudder-sdk-react-native@1.4.1
npm ERR! node_modules/@rudderstack/rudder-sdk-react-native
npm ERR!   @rudderstack/rudder-sdk-react-native@"1.4.1" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
```

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

