### PR TITLE
ci(rudder-sdk-react-native-monorepo): exclude package json from nx affected packages resolution

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -7,3 +7,6 @@ test-setup.ts
 tsconfig.json
 tsconfig.lib.json
 tsconfig.spec.json
+package.json
+package-lock.json
+sonar-project.properties


### PR DESCRIPTION
## Description of the change

exclude package json from nx affected packages resolution

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> https://www.notion.so/rudderstacks/React-Native-deploy-action-to-not-attempt-to-publish-non-affected-packages-and-auto-trigger-on-the-c-e8f95275336e4bdc97895299c22b9977?pvs=4

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
