### PR TITLE
fix: improve getRudderContext api return type 

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -600,7 +600,7 @@ PODS:
     - React-perflogger (= 0.72.4)
   - RNCAsyncStorage (1.19.3):
     - React-Core
-  - RNRudderSdk (1.10.0):
+  - RNRudderSdk (1.11.0):
     - React
     - Rudder (< 2.0.0, >= 1.23.0)
   - RNSVG (13.9.0):
@@ -995,7 +995,7 @@ SPEC CHECKSUMS:
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNCAsyncStorage: c913ede1fa163a71cea118ed4670bbaaa4b511bb
-  RNRudderSdk: aa2beac06f0c83bf30d3c9bb2f9325f82095c368
+  RNRudderSdk: 8d0343201f816e98423e089ccd46289fdb264be1
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   RSCrashReporter: e9ccaebd996263f8325a6cbef44ff74aa5f58e30
   Rudder: 125d9dc03e178b35b0f74487aa694afe1a8e6f4f

--- a/apps/example/src/app/RudderEvents.tsx
+++ b/apps/example/src/app/RudderEvents.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from 'react-native';
-import rudderClient, { RudderContext } from '@rudderstack/rudder-sdk-react-native';
+import rudderClient, { IRudderContext } from '@rudderstack/rudder-sdk-react-native';
 
 const RudderEvents = () => {
   const identify = async () => {
@@ -118,7 +118,7 @@ const RudderEvents = () => {
   };
 
   const getRudderContext = async () => {
-    const context: RudderContext | null = await rudderClient.getRudderContext();
+    const context: IRudderContext | null = await rudderClient.getRudderContext();
     console.log(`${JSON.stringify(context)}`);
   };
 

--- a/apps/example/src/app/RudderEvents.tsx
+++ b/apps/example/src/app/RudderEvents.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from 'react-native';
-import rudderClient, { IRudderContext } from '@rudderstack/rudder-sdk-react-native';
+import rudderClient, { RudderContext } from '@rudderstack/rudder-sdk-react-native';
 
 const RudderEvents = () => {
   const identify = async () => {
@@ -118,7 +118,7 @@ const RudderEvents = () => {
   };
 
   const getRudderContext = async () => {
-    const context: IRudderContext | null = await rudderClient.getRudderContext();
+    const context: RudderContext | null = await rudderClient.getRudderContext();
     console.log(`${JSON.stringify(context)}`);
   };
 

--- a/apps/example/src/app/RudderEvents.tsx
+++ b/apps/example/src/app/RudderEvents.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from 'react-native';
-import rudderClient, { RUDDER_LOG_LEVEL } from '@rudderstack/rudder-sdk-react-native';
+import rudderClient, { IRudderContext } from '@rudderstack/rudder-sdk-react-native';
 
 const RudderEvents = () => {
   const identify = async () => {
@@ -109,6 +109,19 @@ const RudderEvents = () => {
     console.log(`SessionId type: ${typeof sessionId}`);
   };
 
+  const enableOptOut = () => {
+    rudderClient.optOut(true);
+  };
+
+  const disableOptOut = () => {
+    rudderClient.optOut(false);
+  };
+
+  const getRudderContext = async () => {
+    const context: IRudderContext | null = await rudderClient.getRudderContext();
+    console.log(`${JSON.stringify(context)}`);
+  };
+
   return (
     <>
       <Button title="Identify" onPress={identify} />
@@ -122,6 +135,9 @@ const RudderEvents = () => {
       <Button title="endSession()" onPress={endSession} />
       <Button title="RESET" onPress={reset} />
       <Button title="getSessionId()" onPress={getSessionId} />
+      <Button title="enableOptOut()" onPress={enableOptOut} />
+      <Button title="disableOptOut()" onPress={disableOptOut} />
+      <Button title="getRudderContext()" onPress={getRudderContext} />
     </>
   );
 };

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.Callback;
 import com.google.gson.Gson;
 import com.rudderstack.android.sdk.core.RudderClient;
 import com.rudderstack.android.sdk.core.RudderConfig;
+import com.rudderstack.android.sdk.core.RudderContext;
 import com.rudderstack.android.sdk.core.RudderIntegration;
 import com.rudderstack.android.sdk.core.RudderLogger;
 import com.rudderstack.android.sdk.core.RudderProperty;
@@ -182,8 +183,14 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
             promise.resolve(null);
             return;
         }
+
+        RudderContext rudderContext = rudderClient.getRudderContext();
+        if (rudderContext == null) {
+            promise.resolve(null);
+            return;
+        }
         Gson gson = new Gson();
-        JSONObject contextJson = new JSONObject(gson.toJson(rudderClient.getRudderContext()));
+        JSONObject contextJson = new JSONObject(gson.toJson(rudderContext));
         promise.resolve(Utility.convertJSONObjectToWriteAbleMap(contextJson));
     }
 

--- a/libs/sdk/src/IRudderContext.ts
+++ b/libs/sdk/src/IRudderContext.ts
@@ -1,4 +1,4 @@
-interface RudderContext {
+interface IRudderContext {
   userAgent: string;
   screen: {
     width: number;
@@ -42,4 +42,4 @@ interface RudderContext {
   customContextMap: Record<string, unknown>;
 }
 
-export default RudderContext;
+export default IRudderContext;

--- a/libs/sdk/src/IRudderContext.ts
+++ b/libs/sdk/src/IRudderContext.ts
@@ -1,0 +1,45 @@
+interface IRudderContext {
+  userAgent: string;
+  screen: {
+    width: number;
+    height: number;
+    density: number;
+  };
+  timezone: string;
+  os: {
+    version: string;
+    name: string;
+  };
+  traits: Record<string, unknown>;
+  network: {
+    wifi: boolean;
+    cellular: boolean;
+    carrier: string;
+    bluetooth: boolean;
+  };
+  locale: string;
+  device: {
+    id: string;
+    type: string;
+    name: string;
+    manufacturer: string;
+    model: string;
+    advertisingId: string;
+    adTrackingEnabled: boolean;
+    token: string;
+  };
+  library: {
+    version: string;
+    name: string;
+  };
+  app: {
+    namespace: string;
+    version: string;
+    name: string;
+    build: string;
+  };
+  externalId: Array<Record<string, unknown>>;
+  customContextMap: Record<string, unknown>;
+}
+
+export default IRudderContext;

--- a/libs/sdk/src/NativeBridge.ts
+++ b/libs/sdk/src/NativeBridge.ts
@@ -1,5 +1,6 @@
 import { NativeModules } from 'react-native';
 import IDBEncryption from './IDBEncryption';
+import IRudderContext from './IRudderContext';
 
 export interface Configuration {
   dataPlaneUrl?: string;
@@ -52,7 +53,7 @@ export interface Bridge {
   putAnonymousId(id: string): Promise<void>;
   // eslint-disable-next-line @typescript-eslint/ban-types
   registerCallback(integrationName: string, callback: Function): Promise<void>;
-  getRudderContext(): Promise<void>;
+  getRudderContext(): Promise<IRudderContext | null>;
   startSession(sessionId?: string): Promise<void>;
   endSession(): Promise<void>;
   getSessionId(): Promise<number | null>;

--- a/libs/sdk/src/NativeBridge.ts
+++ b/libs/sdk/src/NativeBridge.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import IDBEncryption from './IDBEncryption';
-import IRudderContext from './IRudderContext';
+import RudderContext from './RudderContext';
 
 export interface Configuration {
   dataPlaneUrl?: string;
@@ -53,7 +53,7 @@ export interface Bridge {
   putAnonymousId(id: string): Promise<void>;
   // eslint-disable-next-line @typescript-eslint/ban-types
   registerCallback(integrationName: string, callback: Function): Promise<void>;
-  getRudderContext(): Promise<IRudderContext | null>;
+  getRudderContext(): Promise<RudderContext | null>;
   startSession(sessionId?: string): Promise<void>;
   endSession(): Promise<void>;
   getSessionId(): Promise<number | null>;

--- a/libs/sdk/src/NativeBridge.ts
+++ b/libs/sdk/src/NativeBridge.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import IDBEncryption from './IDBEncryption';
-import RudderContext from './RudderContext';
+import IRudderContext from './IRudderContext';
 
 export interface Configuration {
   dataPlaneUrl?: string;
@@ -53,7 +53,7 @@ export interface Bridge {
   putAnonymousId(id: string): Promise<void>;
   // eslint-disable-next-line @typescript-eslint/ban-types
   registerCallback(integrationName: string, callback: Function): Promise<void>;
-  getRudderContext(): Promise<RudderContext | null>;
+  getRudderContext(): Promise<IRudderContext | null>;
   startSession(sessionId?: string): Promise<void>;
   endSession(): Promise<void>;
   getSessionId(): Promise<number | null>;

--- a/libs/sdk/src/RudderClient.ts
+++ b/libs/sdk/src/RudderClient.ts
@@ -5,7 +5,7 @@ import { configure } from './RudderConfiguration';
 import bridge, { Configuration } from './NativeBridge';
 import { logInit, logDebug, logError, logWarn } from './Logger';
 import { SDK_VERSION } from './Constants';
-import RudderContext from './RudderContext';
+import IRudderContext from './IRudderContext';
 
 const lock = new AsyncLock();
 
@@ -298,8 +298,8 @@ async function registerCallback(name: string, callback: Function) {
   }
 }
 
-async function getRudderContext(): Promise<RudderContext | null> {
-  const context: RudderContext | null = await bridge.getRudderContext();
+async function getRudderContext(): Promise<IRudderContext | null> {
+  const context: IRudderContext | null = await bridge.getRudderContext();
   return context ?? null;
 }
 

--- a/libs/sdk/src/RudderClient.ts
+++ b/libs/sdk/src/RudderClient.ts
@@ -5,6 +5,7 @@ import { configure } from './RudderConfiguration';
 import bridge, { Configuration } from './NativeBridge';
 import { logInit, logDebug, logError, logWarn } from './Logger';
 import { SDK_VERSION } from './Constants';
+import IRudderContext from './IRudderContext';
 
 const lock = new AsyncLock();
 
@@ -297,8 +298,9 @@ async function registerCallback(name: string, callback: Function) {
   }
 }
 
-async function getRudderContext() {
-  return await bridge.getRudderContext();
+async function getRudderContext(): Promise<IRudderContext | null> {
+  const context: IRudderContext | null = await bridge.getRudderContext();
+  return context ?? null;
 }
 
 async function startSession(sessionId?: number): Promise<void> {

--- a/libs/sdk/src/RudderClient.ts
+++ b/libs/sdk/src/RudderClient.ts
@@ -5,7 +5,7 @@ import { configure } from './RudderConfiguration';
 import bridge, { Configuration } from './NativeBridge';
 import { logInit, logDebug, logError, logWarn } from './Logger';
 import { SDK_VERSION } from './Constants';
-import IRudderContext from './IRudderContext';
+import RudderContext from './RudderContext';
 
 const lock = new AsyncLock();
 
@@ -298,8 +298,8 @@ async function registerCallback(name: string, callback: Function) {
   }
 }
 
-async function getRudderContext(): Promise<IRudderContext | null> {
-  const context: IRudderContext | null = await bridge.getRudderContext();
+async function getRudderContext(): Promise<RudderContext | null> {
+  const context: RudderContext | null = await bridge.getRudderContext();
   return context ?? null;
 }
 

--- a/libs/sdk/src/RudderContext.ts
+++ b/libs/sdk/src/RudderContext.ts
@@ -1,4 +1,4 @@
-interface IRudderContext {
+interface RudderContext {
   userAgent: string;
   screen: {
     width: number;
@@ -42,4 +42,4 @@ interface IRudderContext {
   customContextMap: Record<string, unknown>;
 }
 
-export default IRudderContext;
+export default RudderContext;

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -1,6 +1,7 @@
 import rudderClient from './RudderClient';
 import { RUDDER_LOG_LEVEL } from './Logger';
 import IDBEncryption from './IDBEncryption';
+import IRudderContext from './IRudderContext';
 
-export { RUDDER_LOG_LEVEL, IDBEncryption };
+export { RUDDER_LOG_LEVEL, IDBEncryption, IRudderContext };
 export default rudderClient;

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -1,7 +1,7 @@
 import rudderClient from './RudderClient';
 import { RUDDER_LOG_LEVEL } from './Logger';
 import IDBEncryption from './IDBEncryption';
-import RudderContext from './RudderContext';
+import IRudderContext from './IRudderContext';
 
-export { RUDDER_LOG_LEVEL, IDBEncryption, RudderContext };
+export { RUDDER_LOG_LEVEL, IDBEncryption, IRudderContext };
 export default rudderClient;

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -1,7 +1,7 @@
 import rudderClient from './RudderClient';
 import { RUDDER_LOG_LEVEL } from './Logger';
 import IDBEncryption from './IDBEncryption';
-import IRudderContext from './IRudderContext';
+import RudderContext from './RudderContext';
 
-export { RUDDER_LOG_LEVEL, IDBEncryption, IRudderContext };
+export { RUDDER_LOG_LEVEL, IDBEncryption, RudderContext };
 export default rudderClient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,7 +189,7 @@
     },
     "libs/sdk": {
       "name": "@rudderstack/rudder-sdk-react-native",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",


### PR DESCRIPTION
## Description of the change

- Added the `IRudderContext` interface in the React Native SDK, which basically defines the context fields. Now this interface is also exported.
- Change the `getRudderContext` API return type from `void` to `IRudderContext | null`.
- Updated the sample app to use this API.
- Also, added GDPR API in the sample app.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix https://github.com/rudderlabs/rudder-sdk-react-native/issues/263

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
