### PR TITLE
fix: migrate from the instance to the static type variable

### DIFF
--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -28,22 +28,24 @@ import java.lang.InterruptedException;
 
 public class RNRudderSdkModule extends ReactContextBaseJavaModule {
 
-    // Avoid adding any instance type variables here and ensure the variable type is static, as it won't persist after a hard app refresh otherwise.
+    // These values are provided by the React Native bridge, and it's safe if they are not static."
     private final ReactApplicationContext reactContext;
+    private final Application application;
+
+    // Avoid adding any instance type variables here and ensure the variable type is static, as it won't persist after a hard app refresh otherwise.
     private static Map<String, Callback> integrationCallbacks = new HashMap<>();
     static RNRudderSdkModule instance;
     static RudderClient rudderClient;
     private static RNUserSessionPlugin userSessionPlugin;
     static RNParamsConfigurator configParams;
     private static boolean initialized = false;
-    private final Application application;
 
     public RNRudderSdkModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
-        instance = this;
         this.application = (Application) this.reactContext.getApplicationContext();
         RNPreferenceManager.getInstance(this.application);
+        instance = this;
     }
 
     @Override

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -28,7 +28,7 @@ import java.lang.InterruptedException;
 
 public class RNRudderSdkModule extends ReactContextBaseJavaModule {
 
-    // These values are provided by the React Native bridge, and it's safe if they are not static."
+    // These values are provided by the React Native bridge, and it's safe if they are not static.
     private final ReactApplicationContext reactContext;
     private final Application application;
 

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -29,22 +29,22 @@ import java.lang.InterruptedException;
 public class RNRudderSdkModule extends ReactContextBaseJavaModule {
 
     // Avoid adding any instance type variables here and ensure the variable type is static, as it won't persist after a hard app refresh otherwise.
-    private ReactApplicationContext rsReactContext;
+    private final ReactApplicationContext reactContext;
     private static Map<String, Callback> integrationCallbacks = new HashMap<>();
     static RNRudderSdkModule instance;
     static RudderClient rudderClient;
     private static RNUserSessionPlugin userSessionPlugin;
     static RNParamsConfigurator configParams;
     private static boolean initialized = false;
-    private Application application;
+    private final Application application;
     private static RNPreferenceManager preferenceManager;
 
     public RNRudderSdkModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        rsReactContext = reactContext;
+        this.reactContext = reactContext;
         instance = this;
-        application = (Application) rsReactContext.getApplicationContext();
-        preferenceManager = RNPreferenceManager.getInstance(application);
+        this.application = (Application) this.reactContext.getApplicationContext();
+        preferenceManager = RNPreferenceManager.getInstance(this.application);
     }
 
     @Override
@@ -61,7 +61,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
 
             // get the instance of RudderClient
             rudderClient = RudderClient.getInstance(
-                    rsReactContext,
+                    this.reactContext,
                     configParams.writeKey,
                     RNRudderAnalytics.buildWithIntegrations(configBuilder),
                     Utility.convertReadableMapToOptions(rudderOptionsMap)
@@ -107,8 +107,8 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
     }
 
     private void initialiseRNLifeCycleEventListener() {
-        RNLifeCycleEventListener lifeCycleEventListener = new RNLifeCycleEventListener(application, userSessionPlugin);
-        rsReactContext.addLifecycleEventListener(lifeCycleEventListener);
+        RNLifeCycleEventListener lifeCycleEventListener = new RNLifeCycleEventListener(this.application, userSessionPlugin);
+        this.reactContext.addLifecycleEventListener(lifeCycleEventListener);
     }
 
     @ReactMethod

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -37,14 +37,13 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
     static RNParamsConfigurator configParams;
     private static boolean initialized = false;
     private final Application application;
-    private static RNPreferenceManager preferenceManager;
 
     public RNRudderSdkModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         instance = this;
         this.application = (Application) this.reactContext.getApplicationContext();
-        preferenceManager = RNPreferenceManager.getInstance(this.application);
+        RNPreferenceManager.getInstance(this.application);
     }
 
     @Override

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -29,14 +29,14 @@ import java.lang.InterruptedException;
 public class RNRudderSdkModule extends ReactContextBaseJavaModule {
 
     // Avoid adding any instance type variables here and ensure the variable type is static, as it won't persist after a hard app refresh otherwise.
-    private static ReactApplicationContext rsReactContext;
+    private ReactApplicationContext rsReactContext;
     private static Map<String, Callback> integrationCallbacks = new HashMap<>();
     static RNRudderSdkModule instance;
     static RudderClient rudderClient;
     private static RNUserSessionPlugin userSessionPlugin;
     static RNParamsConfigurator configParams;
     private static boolean initialized = false;
-    private static Application application;
+    private Application application;
     private static RNPreferenceManager preferenceManager;
 
     public RNRudderSdkModule(ReactApplicationContext reactContext) {

--- a/libs/sdk/ios/RNRudderSdkModule.h
+++ b/libs/sdk/ios/RNRudderSdkModule.h
@@ -11,12 +11,7 @@
 #import "RNUserSessionPlugin.h"
 
 @interface RNRudderSdkModule : NSObject <RCTBridgeModule> {
-    RNApplicationLifeCycleManager *applicationLifeCycleManager;
-    RNBackGroundModeManager *backGroundModeManager;
-    RNPreferenceManager *preferenceManager;
-    RNParamsConfigurator *configParams;
-    BOOL initialized;
-    RNUserSessionPlugin *session;
+    // Avoid adding any instance type variables here.
 }
 
 


### PR DESCRIPTION
## Description of the change

- Fixes the issue when `live reload` occurs (it can be done by pressing `r` in the simulator, or due to some other factors when `fast refresh` occurs): Previously instance variables were getting cleared in this case. Now, I've migrated the instance to the static type variable which retains its state even when live reload occurs.
- In React Native iOS, this was a major issue, visible clearly, which is fixed.
- In React Native Android, this was mainly affecting the LifeCycle events, which is fixed. Now, I've made sure to initialise the lifecycle whenever live reload occurs - this ensures lifecycle event flows as expected.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
