### PR TITLE
fix: issue with the live reload

### DIFF
--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/LifeCycleEvents.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/LifeCycleEvents.java
@@ -2,6 +2,7 @@ package com.rudderstack.react.android;
 
 import android.app.Application;
 
+import com.rudderstack.android.sdk.core.RudderClient;
 import com.rudderstack.android.sdk.core.RudderLogger;
 import com.rudderstack.android.sdk.core.RudderProperty;
 
@@ -48,7 +49,11 @@ public class LifeCycleEvents {
             RudderProperty property = new RudderProperty()
                     .putValue(VERSION, currentVersion)
                     .putValue("build", currentBuild);
-            RNRudderSdkModule.rudderClient.track("Application Installed", property);
+            if (RudderClient.getInstance() != null) {
+                RudderClient.getInstance().track("Application Installed", property);
+            } else {
+                RudderLogger.logError("RudderClient instance is null. Hence dropping Application Installed event.");
+            }
         }
 
         private void sendApplicationUpdated(int previousBuild, int currentBuild, String previousVersion, String currentVersion) {
@@ -58,7 +63,11 @@ public class LifeCycleEvents {
                     .putValue(VERSION, currentVersion)
                     .putValue("previous_build", previousBuild)
                     .putValue("build", currentBuild);
-            RNRudderSdkModule.rudderClient.track("Application Updated", property);
+            if (RudderClient.getInstance() != null) {
+                RudderClient.getInstance().track("Application Updated", property);
+            } else {
+                RudderLogger.logError("RudderClient instance is null. Hence dropping Application Updated event.");
+            }
         }
     }
 
@@ -80,7 +89,11 @@ public class LifeCycleEvents {
                 this.userSessionPlugin.saveEventTimestamp();
                 RudderProperty property = new RudderProperty();
                 property.put("from_background", this.fromBackground);
-                RNRudderSdkModule.rudderClient.track("Application Opened", property);
+                if (RudderClient.getInstance() != null) {
+                    RudderClient.getInstance().track("Application Opened", property);
+                } else {
+                    RudderLogger.logError("RudderClient instance is null. Hence dropping Application Opened event.");
+                }
             }
         }
     }
@@ -96,7 +109,11 @@ public class LifeCycleEvents {
         public void run() {
             if (RNRudderSdkModule.configParams.trackLifeCycleEvents) {
                 this.userSessionPlugin.saveEventTimestamp();
-                RNRudderSdkModule.rudderClient.track("Application Backgrounded");
+                if (RudderClient.getInstance() != null) {
+                    RudderClient.getInstance().track("Application Backgrounded");
+                } else {
+                    RudderLogger.logError("RudderClient instance is null. Hence dropping Application Backgrounded event.");
+                }
             }
         }
     }
@@ -117,7 +134,11 @@ public class LifeCycleEvents {
                 RudderProperty property = new RudderProperty();
                 property.put("name", activityName);
                 property.put("automatic", true);
-                RNRudderSdkModule.rudderClient.screen(activityName, property);
+                if (RudderClient.getInstance() != null) {
+                    RudderClient.getInstance().screen(activityName, property);
+                } else {
+                    RudderLogger.logError("RudderClient instance is null. Hence dropping Screen View event.");
+                }
             }
         }
     }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/LifeCycleEvents.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/LifeCycleEvents.java
@@ -19,16 +19,18 @@ public class LifeCycleEvents {
         private static AppVersion appVersion;
         public static final String VERSION = "version";
         private final RNUserSessionPlugin userSessionPlugin;
+        private final boolean trackLifeCycleEvents;
 
-        ApplicationStatusRunnable(Application application, RNUserSessionPlugin userSessionPlugin) {
+        ApplicationStatusRunnable(Application application, RNUserSessionPlugin userSessionPlugin, boolean trackLifeCycleEvents) {
             this.userSessionPlugin = userSessionPlugin;
+            this.trackLifeCycleEvents = trackLifeCycleEvents;
             appVersion = new AppVersion(application);
         }
 
         @Override
         public void run() {
             appVersion.storeCurrentBuildAndVersion();
-            if (RNRudderSdkModule.configParams.trackLifeCycleEvents) {
+            if (this.trackLifeCycleEvents) {
                 if (appVersion.previousBuild == -1) {
                     this.userSessionPlugin.saveEventTimestamp();
                     // application was not installed previously, now triggering Application Installed event
@@ -74,15 +76,17 @@ public class LifeCycleEvents {
     static class ApplicationOpenedRunnable implements LifeCycleEventsInterface {
         boolean fromBackground;
         private final RNUserSessionPlugin userSessionPlugin;
+        private final boolean trackLifeCycleEvents;
 
-        ApplicationOpenedRunnable(boolean fromBackground, RNUserSessionPlugin userSessionPlugin) {
+        ApplicationOpenedRunnable(boolean fromBackground, RNUserSessionPlugin userSessionPlugin, boolean trackLifeCycleEvents) {
             this.fromBackground = fromBackground;
             this.userSessionPlugin = userSessionPlugin;
+            this.trackLifeCycleEvents = trackLifeCycleEvents;
         }
 
         @Override
         public void run() {
-            if (RNRudderSdkModule.configParams.trackLifeCycleEvents) {
+            if (this.trackLifeCycleEvents) {
                 if (this.fromBackground) {
                     this.userSessionPlugin.startNewSessionIfCurrentIsExpired();
                 }
@@ -100,14 +104,16 @@ public class LifeCycleEvents {
 
     static class ApplicationBackgroundedRunnable implements LifeCycleEventsInterface {
         private final RNUserSessionPlugin userSessionPlugin;
+        private final boolean trackLifeCycleEvents;
         
-        ApplicationBackgroundedRunnable(RNUserSessionPlugin userSessionPlugin) {
+        ApplicationBackgroundedRunnable(RNUserSessionPlugin userSessionPlugin, boolean trackLifeCycleEvents) {
             this.userSessionPlugin = userSessionPlugin;
+            this.trackLifeCycleEvents = trackLifeCycleEvents;
         }
 
         @Override
         public void run() {
-            if (RNRudderSdkModule.configParams.trackLifeCycleEvents) {
+            if (this.trackLifeCycleEvents) {
                 this.userSessionPlugin.saveEventTimestamp();
                 if (RudderClient.getInstance() != null) {
                     RudderClient.getInstance().track("Application Backgrounded");
@@ -121,15 +127,17 @@ public class LifeCycleEvents {
     static class ScreenViewRunnable implements LifeCycleEventsInterface {
         String activityName;
         private final RNUserSessionPlugin userSessionPlugin;
+        private final boolean recordScreenViews;
 
-        ScreenViewRunnable(String activityName, RNUserSessionPlugin userSessionPlugin) {
+        ScreenViewRunnable(String activityName, RNUserSessionPlugin userSessionPlugin, boolean recordScreenViews) {
             this.activityName = activityName;
             this.userSessionPlugin = userSessionPlugin;
+            this.recordScreenViews = recordScreenViews;
         }
 
         @Override
         public void run() {
-            if (RNRudderSdkModule.configParams.recordScreenViews) {
+            if (this.recordScreenViews) {
                 this.userSessionPlugin.saveEventTimestamp();
                 RudderProperty property = new RudderProperty();
                 property.put("name", activityName);

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNLifeCycleEventListener.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNLifeCycleEventListener.java
@@ -13,8 +13,8 @@ import static com.rudderstack.react.android.LifeCycleEvents.ScreenViewRunnable;
 
 public class RNLifeCycleEventListener implements LifecycleEventListener {
 
-    private static int noOfActivities;
-    private static boolean fromBackground = false;
+    private int noOfActivities;
+    private boolean fromBackground = false;
     private final RNUserSessionPlugin userSessionPlugin;
     private final RNRudderSdkModule instance;
     private final boolean trackLifeCycleEvents;

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNLifeCycleEventListener.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNLifeCycleEventListener.java
@@ -16,10 +16,16 @@ public class RNLifeCycleEventListener implements LifecycleEventListener {
     private static int noOfActivities;
     private static boolean fromBackground = false;
     private final RNUserSessionPlugin userSessionPlugin;
+    private final RNRudderSdkModule instance;
+    private final boolean trackLifeCycleEvents;
+    private boolean recordScreenViews;
 
-    RNLifeCycleEventListener(Application application, RNUserSessionPlugin userSessionPlugin) {
+    RNLifeCycleEventListener(Application application, RNUserSessionPlugin userSessionPlugin, RNRudderSdkModule instance, boolean trackLifeCycleEvents, boolean recordScreenViews) {
         this.userSessionPlugin = userSessionPlugin;
-        ApplicationStatusRunnable applicationStatus = new ApplicationStatusRunnable(application, this.userSessionPlugin);
+        this.instance = instance;
+        this.trackLifeCycleEvents = trackLifeCycleEvents;
+        this.recordScreenViews = recordScreenViews;
+        ApplicationStatusRunnable applicationStatus = new ApplicationStatusRunnable(application, this.userSessionPlugin, this.trackLifeCycleEvents);
         executeRunnable(applicationStatus);
     }
 
@@ -28,12 +34,12 @@ public class RNLifeCycleEventListener implements LifecycleEventListener {
         noOfActivities += 1;
         if (noOfActivities == 1) {
             // no previous activity present. Application Opened
-            ApplicationOpenedRunnable openedRunnable = new ApplicationOpenedRunnable(fromBackground, this.userSessionPlugin);
+            ApplicationOpenedRunnable openedRunnable = new ApplicationOpenedRunnable(fromBackground, this.userSessionPlugin, this.trackLifeCycleEvents);
             executeRunnable(openedRunnable);
         }
-        Activity activity = RNRudderSdkModule.instance.getCurrentActivityFromReact();
+        Activity activity = this.instance.getCurrentActivityFromReact();
         if (activity != null && activity.getLocalClassName() != null) {
-            ScreenViewRunnable screenViewRunnable = new ScreenViewRunnable(activity.getLocalClassName(), this.userSessionPlugin);
+            ScreenViewRunnable screenViewRunnable = new ScreenViewRunnable(activity.getLocalClassName(), this.userSessionPlugin, this.recordScreenViews);
             executeRunnable(screenViewRunnable);
         }
     }
@@ -43,7 +49,7 @@ public class RNLifeCycleEventListener implements LifecycleEventListener {
         fromBackground = true;
         noOfActivities -= 1;
         if (noOfActivities == 0) {
-            ApplicationBackgroundedRunnable backgroundedRunnable = new ApplicationBackgroundedRunnable(this.userSessionPlugin);
+            ApplicationBackgroundedRunnable backgroundedRunnable = new ApplicationBackgroundedRunnable(this.userSessionPlugin, this.trackLifeCycleEvents);
             executeRunnable(backgroundedRunnable);
         }
     }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -85,7 +85,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
                     RudderClient.Callback callback = new NativeCallBack(integrationName);
                     rudderClient.onIntegrationReady(integrationName, callback);
                 }
-            }g
+            }
         } else {
             RudderLogger.logVerbose("Rudder Client already initialized, Ignoring the new setup call");
         }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -31,17 +31,14 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
     private final ReactApplicationContext reactContext;
     private static Map<String, Callback> integrationCallbacks = new HashMap<>();
 
-    static RNRudderSdkModule instance;
     private RudderClient rudderClient;
     private RNUserSessionPlugin userSessionPlugin;
-    static RNParamsConfigurator configParams;
     private boolean initialized = false;
     private final Application application;
 
     public RNRudderSdkModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
-        instance = this;
         this.application = (Application) this.reactContext.getApplicationContext();
         RNPreferenceManager.getInstance(this.application);
     }
@@ -55,7 +52,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
     public void setup(ReadableMap config, ReadableMap rudderOptionsMap, Promise promise) throws InterruptedException {
         if (!isRudderClientInitializedAndReady()) {
             // create the config object
-            configParams = new RNParamsConfigurator(config);
+            RNParamsConfigurator configParams = new RNParamsConfigurator(config);
             RudderConfig.Builder configBuilder = configParams.handleConfig();
 
             // get the instance of RudderClient
@@ -75,7 +72,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
             userSessionPlugin.handleSessionTracking();
 
             // Track automatic lifecycle and/or screen events
-            RNLifeCycleEventListener lifeCycleEventListener = new RNLifeCycleEventListener(this.application, userSessionPlugin);
+            RNLifeCycleEventListener lifeCycleEventListener = new RNLifeCycleEventListener(this.application, userSessionPlugin, this, configParams.trackLifeCycleEvents, configParams.recordScreenViews);
             reactContext.addLifecycleEventListener(lifeCycleEventListener);
 
             // RN SDK is initialised
@@ -88,7 +85,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
                     RudderClient.Callback callback = new NativeCallBack(integrationName);
                     rudderClient.onIntegrationReady(integrationName, callback);
                 }
-            }
+            }g
         } else {
             RudderLogger.logVerbose("Rudder Client already initialized, Ignoring the new setup call");
         }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -37,14 +37,13 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
     static RNParamsConfigurator configParams;
     private boolean initialized = false;
     private final Application application;
-    private static RNPreferenceManager preferenceManager;
 
     public RNRudderSdkModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         instance = this;
         this.application = (Application) this.reactContext.getApplicationContext();
-        preferenceManager = RNPreferenceManager.getInstance(this.application);
+        RNPreferenceManager.getInstance(this.application);
     }
 
     @Override

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -35,7 +35,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
     private RudderClient rudderClient;
     private static RNUserSessionPlugin userSessionPlugin;
     static RNParamsConfigurator configParams;
-    static boolean initialized = false;
+    private boolean initialized = false;
     private final Application application;
     private static RNPreferenceManager preferenceManager;
 

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -32,7 +32,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
     private static Map<String, Callback> integrationCallbacks = new HashMap<>();
 
     static RNRudderSdkModule instance;
-    static RudderClient rudderClient;
+    private RudderClient rudderClient;
     private static RNUserSessionPlugin userSessionPlugin;
     static RNParamsConfigurator configParams;
     static boolean initialized = false;
@@ -87,7 +87,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
                 for (RudderIntegration.Factory factory : RNRudderAnalytics.integrationList) {
                     String integrationName = factory.key();
                     RudderClient.Callback callback = new NativeCallBack(integrationName);
-                    RNRudderSdkModule.rudderClient.onIntegrationReady(integrationName, callback);
+                    rudderClient.onIntegrationReady(integrationName, callback);
                 }
             }
         } else {

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -33,7 +33,7 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
 
     static RNRudderSdkModule instance;
     private RudderClient rudderClient;
-    private static RNUserSessionPlugin userSessionPlugin;
+    private RNUserSessionPlugin userSessionPlugin;
     static RNParamsConfigurator configParams;
     private boolean initialized = false;
     private final Application application;


### PR DESCRIPTION
## Description of the change

- Fixes the issue when `live reload` occurs (it can be done by pressing `r` in the simulator, or due to some other factors when `fast refresh` occurs): Now, whenever live reload occurs, the Rudder React Native SDK will need to be explicitly initialized before it starts functioning.
- In React Native iOS, this was a major issue, visible clearly, which is fixed.
- In React Native Android, this was mainly affecting the LifeCycle events, which is fixed.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
