### PR TITLE
fix: incorrect tracking of application lifecycle events

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Amplitude (8.16.0):
     - AnalyticsConnector (~> 1.0.0)
-  - AnalyticsConnector (1.0.1)
+  - AnalyticsConnector (1.0.3)
   - AppCenter (5.0.4):
     - AppCenter/Analytics (= 5.0.4)
     - AppCenter/Crashes (= 5.0.4)
@@ -45,13 +45,13 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCore (10.16.0):
+  - FirebaseCore (10.18.0):
     - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.16.0):
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreInternal (10.18.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.16.0):
+  - FirebaseInstallations (10.18.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -136,38 +136,38 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleUtilities (7.11.5):
-    - GoogleUtilities/AppDelegateSwizzler (= 7.11.5)
-    - GoogleUtilities/Environment (= 7.11.5)
-    - GoogleUtilities/ISASwizzler (= 7.11.5)
-    - GoogleUtilities/Logger (= 7.11.5)
-    - GoogleUtilities/MethodSwizzler (= 7.11.5)
-    - GoogleUtilities/Network (= 7.11.5)
-    - "GoogleUtilities/NSData+zlib (= 7.11.5)"
-    - GoogleUtilities/Reachability (= 7.11.5)
-    - GoogleUtilities/SwizzlerTestHelpers (= 7.11.5)
-    - GoogleUtilities/UserDefaults (= 7.11.5)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.5):
+  - GoogleUtilities (7.12.0):
+    - GoogleUtilities/AppDelegateSwizzler (= 7.12.0)
+    - GoogleUtilities/Environment (= 7.12.0)
+    - GoogleUtilities/ISASwizzler (= 7.12.0)
+    - GoogleUtilities/Logger (= 7.12.0)
+    - GoogleUtilities/MethodSwizzler (= 7.12.0)
+    - GoogleUtilities/Network (= 7.12.0)
+    - "GoogleUtilities/NSData+zlib (= 7.12.0)"
+    - GoogleUtilities/Reachability (= 7.12.0)
+    - GoogleUtilities/SwizzlerTestHelpers (= 7.12.0)
+    - GoogleUtilities/UserDefaults (= 7.12.0)
+  - GoogleUtilities/AppDelegateSwizzler (7.12.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.5):
+  - GoogleUtilities/Environment (7.12.0):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/ISASwizzler (7.11.5)
-  - GoogleUtilities/Logger (7.11.5):
+  - GoogleUtilities/ISASwizzler (7.12.0)
+  - GoogleUtilities/Logger (7.12.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.11.5):
+  - GoogleUtilities/MethodSwizzler (7.12.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.11.5):
+  - GoogleUtilities/Network (7.12.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.5)"
-  - GoogleUtilities/Reachability (7.11.5):
+  - "GoogleUtilities/NSData+zlib (7.12.0)"
+  - GoogleUtilities/Reachability (7.12.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/SwizzlerTestHelpers (7.11.5):
+  - GoogleUtilities/SwizzlerTestHelpers (7.12.0):
     - GoogleUtilities/MethodSwizzler
-  - GoogleUtilities/UserDefaults (7.11.5):
+  - GoogleUtilities/UserDefaults (7.12.0):
     - GoogleUtilities/Logger
   - hermes-engine (0.72.4):
     - hermes-engine/Pre-built (= 0.72.4)
@@ -176,12 +176,12 @@ PODS:
   - MetricsReporter (1.1.1):
     - RSCrashReporter (= 1.0.0)
     - RudderKit (= 1.4.0)
-  - MoEngage-iOS-SDK (9.12.0)
-  - nanopb (2.30909.0):
-    - nanopb/decode (= 2.30909.0)
-    - nanopb/encode (= 2.30909.0)
-  - nanopb/decode (2.30909.0)
-  - nanopb/encode (2.30909.0)
+  - MoEngage-iOS-SDK (9.13.0)
+  - nanopb (2.30909.1):
+    - nanopb/decode (= 2.30909.1)
+    - nanopb/encode (= 2.30909.1)
+  - nanopb/decode (2.30909.1)
+  - nanopb/encode (2.30909.1)
   - OpenSSL-Universal (1.1.1100)
   - PromisesObjC (2.3.1)
   - RCT-Folly (2021.07.22.00):
@@ -606,7 +606,7 @@ PODS:
   - RNSVG (13.9.0):
     - React-Core
   - RSCrashReporter (1.0.0)
-  - Rudder (1.23.0):
+  - Rudder (1.23.1):
     - MetricsReporter (= 1.1.1)
   - Rudder-Amplitude (1.1.1):
     - Amplitude (= 8.16.0)
@@ -674,9 +674,9 @@ PODS:
     - Rudder (~> 1.21)
     - SQLCipher (~> 4.0)
   - RudderKit (1.4.0)
-  - SDWebImage (5.18.2):
-    - SDWebImage/Core (= 5.18.2)
-  - SDWebImage/Core (5.18.2)
+  - SDWebImage (5.18.5):
+    - SDWebImage/Core (= 5.18.5)
+  - SDWebImage/Core (5.18.5)
   - Singular-SDK (11.0.4):
     - Singular-SDK/Main (= 11.0.4)
   - Singular-SDK/Main (11.0.4)
@@ -928,7 +928,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Amplitude: 4daad8eb8193b15353221dfd96c52220367cb3e8
-  AnalyticsConnector: eccd7e1cd3dd18e6bd09ac2506e37d4ed43ba3f4
+  AnalyticsConnector: a53214d38ae22734c6266106c0492b37832633a9
   AppCenter: 85c92db0759d2792a65eb61d6842d2e86611a49a
   AppsFlyerFramework: 6eb4d89d2eb9a6632317f1055b359d9fd85fd5ff
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
@@ -939,9 +939,9 @@ SPEC CHECKSUMS:
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: aa0d2420d208c9314624e14bb417782fd5f30d29
   FirebaseAnalytics: 9a12e090ead49f8877ed8132ae920e3cbbd2fcd0
-  FirebaseCore: 65a801af84cca84361ef9eac3fd868656968a53b
-  FirebaseCoreInternal: 26233f705cc4531236818a07ac84d20c333e505a
-  FirebaseInstallations: b822f91a61f7d1ba763e5ccc9d4f2e6f2ed3b3ee
+  FirebaseCore: 2322423314d92f946219c8791674d2f3345b598f
+  FirebaseCoreInternal: 8eb002e564b533bdcf1ba011f33f2b5c10e2ed4a
+  FirebaseInstallations: e842042ec6ac1fd2e37d7706363ebe7f662afea4
   Flipper: 6edb735e6c3e332975d1b17956bcc584eccf5818
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -953,12 +953,12 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   GoogleAppMeasurement: 3ae505b44174bcc0775f5c86cecc5826259fbb1e
-  GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
+  GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
   hermes-engine: 81191603c4eaa01f5e4ae5737a9efcf64756c7b2
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MetricsReporter: 759631361ffd2b8f0d375b1225c8a631311f6da2
-  MoEngage-iOS-SDK: a5c11bbbbecab2629395709cb6c7ad5f5de9ee6e
-  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
+  MoEngage-iOS-SDK: 4da6190f464f11f66dd0fa6ef827948e59998257
+  nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
@@ -998,7 +998,7 @@ SPEC CHECKSUMS:
   RNRudderSdk: eaeeae19b067e82270726ec19fdf1bdefee569fd
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   RSCrashReporter: e9ccaebd996263f8325a6cbef44ff74aa5f58e30
-  Rudder: 125d9dc03e178b35b0f74487aa694afe1a8e6f4f
+  Rudder: 18897c785af9cfe84c2be2a1d15a645edbeda6d0
   Rudder-Amplitude: a353ca07ba381d23ae587f2f74ea79a6c1563145
   Rudder-AppCenter: 9eca9241e3707a0e9610714dd91dc8da4bae7e1f
   Rudder-Appsflyer: 8108ad9e323a5c0e9aeecdbfc4fa2dfe68497146
@@ -1018,7 +1018,7 @@ SPEC CHECKSUMS:
   Rudder-Singular: e22a4101ce043aded86b777bea873bf6a2af42b9
   RudderDatabaseEncryption: 95b436538412958eda771f5d81bd970a9ffe4eec
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
-  SDWebImage: c0de394d7cf7f9838aed1fd6bb6037654a4572e4
+  SDWebImage: 7ac2b7ddc5e8484c79aa90fc4e30b149d6a2c88f
   Singular-SDK: 614350e3ed21a06b02ab165b370b212f8aaacf2b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   SQLCipher: f2e96b3822e3006b379181a0e4fd145f6de29b56

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -600,7 +600,7 @@ PODS:
     - React-perflogger (= 0.72.4)
   - RNCAsyncStorage (1.19.3):
     - React-Core
-  - RNRudderSdk (1.11.0):
+  - RNRudderSdk (1.11.1):
     - React
     - Rudder (< 2.0.0, >= 1.23.0)
   - RNSVG (13.9.0):
@@ -995,7 +995,7 @@ SPEC CHECKSUMS:
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNCAsyncStorage: c913ede1fa163a71cea118ed4670bbaaa4b511bb
-  RNRudderSdk: 8d0343201f816e98423e089ccd46289fdb264be1
+  RNRudderSdk: eaeeae19b067e82270726ec19fdf1bdefee569fd
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
   RSCrashReporter: e9ccaebd996263f8325a6cbef44ff74aa5f58e30
   Rudder: 125d9dc03e178b35b0f74487aa694afe1a8e6f4f

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNPreferenceManager.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNPreferenceManager.java
@@ -90,7 +90,7 @@ public class RNPreferenceManager {
     
     public void migrateAppInfoPreferencesWhenRNPrefDoesNotExist() {
         if (!Utility.isGivenPreferenceFileEmpty(REACT_NATIVE_PREFS_NAME, this.application)) {
-            RudderLogger.logVerbose("RNRudderSdkModule: No migration needed, as react native preferences file exists and it's not empty");
+            RudderLogger.logVerbose("RNPreferenceManager: No migration needed, as react native preferences file exists and it's not empty");
             return;
         }
         migrateAppInfoPreferencesFromNative();
@@ -98,10 +98,10 @@ public class RNPreferenceManager {
 
     private void migrateAppInfoPreferencesFromNative() {
         if (Utility.isGivenPreferenceFileEmpty(NATIVE_PREFS_NAME, this.application)) {
-            RudderLogger.logVerbose("RNRudderSdkModule: No migration needed, as native preferences file does not exist or it's empty.");
+            RudderLogger.logVerbose("RNPreferenceManager: No migration needed, as native preferences file does not exist or it's empty.");
             return;
         }
-        RudderLogger.logDebug("RNRudderSdkModule: Performing App Info migration.");
+        RudderLogger.logDebug("RNPreferenceManager: Performing App Info migration.");
         SharedPreferences nativePrefs = this.application.getSharedPreferences(NATIVE_PREFS_NAME, Context.MODE_PRIVATE);
         if (nativePrefs.contains(RUDDER_APPLICATION_BUILD_KEY)) {
             saveBuildNumber(nativePrefs.getInt(RUDDER_APPLICATION_BUILD_KEY, -1));

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNPreferenceManager.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNPreferenceManager.java
@@ -90,7 +90,7 @@ public class RNPreferenceManager {
     
     public void migrateAppInfoPreferencesWhenRNPrefDoesNotExist() {
         if (!Utility.isGivenPreferenceFileEmpty(REACT_NATIVE_PREFS_NAME, this.application)) {
-            RudderLogger.logVerbose("RNPreferenceManager: No migration needed, as react native preferences file exists and it's not empty");
+            // No migration needed, as react native preferences file exists and it's not empty
             return;
         }
         migrateAppInfoPreferencesFromNative();
@@ -98,10 +98,10 @@ public class RNPreferenceManager {
 
     private void migrateAppInfoPreferencesFromNative() {
         if (Utility.isGivenPreferenceFileEmpty(NATIVE_PREFS_NAME, this.application)) {
-            RudderLogger.logVerbose("RNPreferenceManager: No migration needed, as native preferences file does not exist or it's empty.");
+            // No migration needed, as native preferences file does not exist or it's empty
             return;
         }
-        RudderLogger.logDebug("RNPreferenceManager: Performing App Info migration.");
+        // Migrate app info preferences from native to react native
         SharedPreferences nativePrefs = this.application.getSharedPreferences(NATIVE_PREFS_NAME, Context.MODE_PRIVATE);
         if (nativePrefs.contains(RUDDER_APPLICATION_BUILD_KEY)) {
             saveBuildNumber(nativePrefs.getInt(RUDDER_APPLICATION_BUILD_KEY, -1));

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNPreferenceManager.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNPreferenceManager.java
@@ -4,7 +4,6 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import com.rudderstack.android.sdk.core.RudderClient;
 import com.rudderstack.android.sdk.core.RudderLogger;
 
 import javax.annotation.Nonnull;
@@ -90,7 +89,7 @@ public class RNPreferenceManager {
     }
     
     public void migrateAppInfoPreferencesWhenRNPrefDoesNotExist() {
-        if (!Utility.isGivePreferenceFileEmpty(REACT_NATIVE_PREFS_NAME, this.application)) {
+        if (!Utility.isGivenPreferenceFileEmpty(REACT_NATIVE_PREFS_NAME, this.application)) {
             RudderLogger.logVerbose("RNRudderSdkModule: No migration needed, as react native preferences file exists and it's not empty");
             return;
         }
@@ -98,7 +97,7 @@ public class RNPreferenceManager {
     }
 
     private void migrateAppInfoPreferencesFromNative() {
-        if (Utility.isGivePreferenceFileEmpty(NATIVE_PREFS_NAME, this.application)) {
+        if (Utility.isGivenPreferenceFileEmpty(NATIVE_PREFS_NAME, this.application)) {
             RudderLogger.logVerbose("RNRudderSdkModule: No migration needed, as native preferences file does not exist or it's empty.");
             return;
         }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNPreferenceManager.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNPreferenceManager.java
@@ -87,26 +87,15 @@ public class RNPreferenceManager {
     boolean getManualSessionTrackingStatus() {
         return preferences.getBoolean(RUDDER_SESSION_MANUAL_TRACKING_STATUS_KEY, false);
     }
-    
-    public void migrateAppInfoPreferencesWhenRNPrefDoesNotExist() {
-        if (!Utility.isGivenPreferenceFileEmpty(REACT_NATIVE_PREFS_NAME, this.application)) {
-            // No migration needed, as react native preferences file exists and it's not empty
-            return;
-        }
-        migrateAppInfoPreferencesFromNative();
-    }
 
-    private void migrateAppInfoPreferencesFromNative() {
-        if (Utility.isGivenPreferenceFileEmpty(NATIVE_PREFS_NAME, this.application)) {
-            // No migration needed, as native preferences file does not exist or it's empty
-            return;
-        }
-        // Migrate app info preferences from native to react native
+    public void migrateAppInfoPreferencesWhenRNPrefDoesNotExist() {
         SharedPreferences nativePrefs = this.application.getSharedPreferences(NATIVE_PREFS_NAME, Context.MODE_PRIVATE);
-        if (nativePrefs.contains(RUDDER_APPLICATION_BUILD_KEY)) {
+        if (!preferences.contains(RUDDER_APPLICATION_BUILD_KEY) &&
+                nativePrefs.contains(RUDDER_APPLICATION_BUILD_KEY)) {
             saveBuildNumber(nativePrefs.getInt(RUDDER_APPLICATION_BUILD_KEY, -1));
         }
-        if (nativePrefs.contains(RUDDER_APPLICATION_VERSION_KEY)) {
+        if (!preferences.contains(RUDDER_APPLICATION_VERSION_KEY) &&
+                nativePrefs.contains(RUDDER_APPLICATION_VERSION_KEY)) {
             saveVersionName(nativePrefs.getString(RUDDER_APPLICATION_VERSION_KEY, null));
         }
     }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModule.java
@@ -41,7 +41,8 @@ public class RNRudderSdkModule extends ReactContextBaseJavaModule {
         super(reactContext);
         this.reactContext = reactContext;
         this.application = (Application) this.reactContext.getApplicationContext();
-        RNPreferenceManager.getInstance(this.application);
+        RNPreferenceManager preferenceManager = RNPreferenceManager.getInstance(this.application);
+        preferenceManager.migrateAppInfoPreferencesWhenRNPrefDoesNotExist();
     }
 
     @Override

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
@@ -185,7 +185,7 @@ public class Utility {
         return str == null || str.length() == 0;
     }
 
-    public static boolean isGivePreferenceFileEmpty(String preferenceFileName, Application application) {
+    public static boolean isGivenPreferenceFileEmpty(String preferenceFileName, Application application) {
         SharedPreferences preference = application.getSharedPreferences(preferenceFileName, Context.MODE_PRIVATE);
         return (preference != null && preference.getAll().size() == 0);
     }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
@@ -1,5 +1,9 @@
 package com.rudderstack.react.android;
 
+import android.app.Application;
+import android.content.Context;
+import android.content.SharedPreferences;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
@@ -179,5 +183,10 @@ public class Utility {
     @Nonnull
     public static boolean isEmpty(String str) {
         return str == null || str.length() == 0;
+    }
+
+    public static boolean isGivePreferenceFileEmpty(String preferenceFileName, Application application) {
+        SharedPreferences preference = application.getSharedPreferences(preferenceFileName, Context.MODE_PRIVATE);
+        return (preference != null && preference.getAll().size() == 0);
     }
 }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
@@ -187,6 +187,6 @@ public class Utility {
 
     public static boolean isGivenPreferenceFileEmpty(String preferenceFileName, Application application) {
         SharedPreferences preference = application.getSharedPreferences(preferenceFileName, Context.MODE_PRIVATE);
-        return (preference != null && preference.getAll().size() == 0);
+        return (preference == null || preference.getAll().size() == 0);
     }
 }

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
@@ -1,9 +1,5 @@
 package com.rudderstack.react.android;
 
-import android.app.Application;
-import android.content.Context;
-import android.content.SharedPreferences;
-
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
@@ -183,10 +179,5 @@ public class Utility {
     @Nonnull
     public static boolean isEmpty(String str) {
         return str == null || str.length() == 0;
-    }
-
-    public static boolean isGivenPreferenceFileEmpty(String preferenceFileName, Application application) {
-        SharedPreferences preference = application.getSharedPreferences(preferenceFileName, Context.MODE_PRIVATE);
-        return (preference == null || preference.getAll().size() == 0);
     }
 }

--- a/libs/sdk/ios/RNPreferenceManager.h
+++ b/libs/sdk/ios/RNPreferenceManager.h
@@ -37,6 +37,8 @@ extern NSString *const RNSessionManualTrackStatus;
 - (void) saveManualSessionTrackingStatus:(BOOL) manualTrackingStatus;
 - (BOOL) getManualSessionTrackingStatus;
 
+- (void) migrateAppInfoPreferencesWhenRNPrefDoesNotExist;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/sdk/ios/RNPreferenceManager.m
+++ b/libs/sdk/ios/RNPreferenceManager.m
@@ -17,6 +17,9 @@ static RNPreferenceManager *instance;
 
 @implementation RNPreferenceManager
 
+NSString *const NativeApplicationBuildKey = @"rl_application_build_key";
+NSString *const NativeApplicationVersionKey = @"rl_application_version_key";
+
 NSString *const RNPrefsKey = @"rn_prefs";
 NSString *const RNApplicationBuildKey = @"rn_application_build_key";
 NSString *const RNApplicationVersionKey = @"rn_application_version_key";
@@ -84,6 +87,19 @@ NSString *const RNSessionManualTrackStatus = @"rn_session_manual_track_status";
 
 - (BOOL) getManualSessionTrackingStatus {
     return [[NSUserDefaults standardUserDefaults] boolForKey:RNSessionManualTrackStatus];
+}
+
+- (void) migrateAppInfoPreferencesWhenRNPrefDoesNotExist {
+    if ([[NSUserDefaults standardUserDefaults] objectForKey:RNApplicationBuildKey] == nil &&
+        [[NSUserDefaults standardUserDefaults] objectForKey:NativeApplicationBuildKey] != nil) {
+        [self saveBuildNumber:[[NSUserDefaults standardUserDefaults] valueForKey:NativeApplicationBuildKey]];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+    if ([[NSUserDefaults standardUserDefaults] objectForKey:RNApplicationVersionKey] == nil &&
+        [[NSUserDefaults standardUserDefaults] objectForKey:NativeApplicationVersionKey] != nil) {
+        [self saveVersionNumber:[[NSUserDefaults standardUserDefaults] valueForKey:NativeApplicationVersionKey]];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
 }
 
 @end

--- a/libs/sdk/ios/RNPreferenceManager.m
+++ b/libs/sdk/ios/RNPreferenceManager.m
@@ -93,12 +93,10 @@ NSString *const RNSessionManualTrackStatus = @"rn_session_manual_track_status";
     if ([[NSUserDefaults standardUserDefaults] objectForKey:RNApplicationBuildKey] == nil &&
         [[NSUserDefaults standardUserDefaults] objectForKey:NativeApplicationBuildKey] != nil) {
         [self saveBuildNumber:[[NSUserDefaults standardUserDefaults] valueForKey:NativeApplicationBuildKey]];
-        [[NSUserDefaults standardUserDefaults] synchronize];
     }
     if ([[NSUserDefaults standardUserDefaults] objectForKey:RNApplicationVersionKey] == nil &&
         [[NSUserDefaults standardUserDefaults] objectForKey:NativeApplicationVersionKey] != nil) {
         [self saveVersionNumber:[[NSUserDefaults standardUserDefaults] valueForKey:NativeApplicationVersionKey]];
-        [[NSUserDefaults standardUserDefaults] synchronize];
     }
 }
 

--- a/libs/sdk/ios/RNRudderSdkModule.m
+++ b/libs/sdk/ios/RNRudderSdkModule.m
@@ -26,6 +26,7 @@ RCT_EXPORT_METHOD(setup:(NSDictionary*)config options:(NSDictionary*) _options r
 
         [RSLogger logDebug:@"setup: Initiating RNPreferenceManager"];
         self->preferenceManager = [RNPreferenceManager getInstance];
+        [self->preferenceManager migrateAppInfoPreferencesWhenRNPrefDoesNotExist];
 
         [RSClient getInstance:self->configParams.writeKey config:[RNRudderAnalytics buildWithIntegrations:configBuilder] options:[self getRudderOptionsObject:_options]];
 


### PR DESCRIPTION
## Description of the change

- When upgrading the React Native SDK from version `1.7.1` to `1.11.1` (the latest version as of now), the Application Installed event is mistakenly fired instead of the Application Updated event. This PR resolves this issue, ensuring that the Application Updated event is now correctly triggered during the upgrade process.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
