### PR TITLE
fix: add a wrapper for the enable and disable analytics APIs in AppCenter

### DIFF
--- a/apps/example/src/app/RudderEvents.tsx
+++ b/apps/example/src/app/RudderEvents.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Button, Platform } from 'react-native';
 import rudderClient, { IRudderContext } from '@rudderstack/rudder-sdk-react-native';
+import {
+  enableAnalytics,
+  disableAnalytics,
+} from '@rudderstack/rudder-integration-appcenter-react-native';
 
 const RudderEvents = () => {
   const identify = async () => {
@@ -140,6 +144,14 @@ const RudderEvents = () => {
     console.log('Cleared Advertising ID');
   };
 
+  const enableAppCenterAnalytics = async () => {
+    await enableAnalytics();
+  };
+
+  const disableAppCenterAnalytics = async () => {
+    await disableAnalytics();
+  };
+
   return (
     <>
       <Button title="Identify" onPress={identify} />
@@ -158,6 +170,8 @@ const RudderEvents = () => {
       <Button title="getRudderContext()" onPress={getRudderContext} />
       <Button title="putAdvertisingId()" onPress={putAdvertisingId} />
       <Button title="clearAdvertisingId()" onPress={clearAdvertisingId} />
+      <Button title="enable AppCenter Analytics()" onPress={enableAppCenterAnalytics} />
+      <Button title="disable AppCenter Analytics()" onPress={disableAppCenterAnalytics} />
     </>
   );
 };

--- a/libs/rudder-integration-appcenter-react-native/src/appcenter.ts
+++ b/libs/rudder-integration-appcenter-react-native/src/appcenter.ts
@@ -4,4 +4,13 @@ async function setup() {
   await bridge.setup();
 }
 
+async function enableAnalytics() {
+  await bridge.enableAnalytics();
+}
+
+async function disableAnalytics() {
+  await bridge.disableAnalytics();
+}
+
+export { enableAnalytics, disableAnalytics };
 export default setup;

--- a/libs/rudder-integration-appcenter-react-native/src/index.ts
+++ b/libs/rudder-integration-appcenter-react-native/src/index.ts
@@ -1,3 +1,5 @@
 import appcenter from './appcenter';
 
+export { enableAnalytics, disableAnalytics } from './appcenter';
+
 export default appcenter;


### PR DESCRIPTION
## Description of the change

- In this PR, we've addressed an issue that arose when we changed our bundling approach for all React Native packages approximately a year ago. Previously, we distributed individual files that users could import directly and use. However, with the bundling process change, we now provide only a single `index.esm.js` file containing all the changes. Consequently, the previous imports are no longer functional.
- Additionally, our implementation of the `enableAnalytics` and `disableAnalytics` APIs was inadequate. Previously, we directly called the corresponding native (Android & iOS) module's API using the `bridge`. However, with the bundling change, that bridge was no longer exported, leading to a breaking change.
- To remedy this, we've introduced a wrapper for those APIs within the React Native module and exported it. Now, users can import this API and perform the required operation.


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
