### PR TITLE
fix: update the version of iOS SDK to address the Privacy Manifest issue

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -10,9 +10,9 @@ PODS:
   - AppCenter/Core (5.0.4)
   - AppCenter/Crashes (5.0.4):
     - AppCenter/Core
-  - AppsFlyerFramework (6.13.2):
-    - AppsFlyerFramework/Main (= 6.13.2)
-  - AppsFlyerFramework/Main (6.13.2)
+  - AppsFlyerFramework (6.14.2):
+    - AppsFlyerFramework/Main (= 6.14.2)
+  - AppsFlyerFramework/Main (6.14.2)
   - boost (1.83.0)
   - BrazeKit (7.5.0)
   - CleverTap-iOS-SDK (4.2.2):
@@ -45,13 +45,13 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCore (10.23.1):
+  - FirebaseCore (10.24.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.23.0):
+  - FirebaseCoreInternal (10.24.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.23.0):
+  - FirebaseInstallations (10.24.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -1237,13 +1237,13 @@ PODS:
     - React-perflogger (= 0.73.2)
   - RNCAsyncStorage (1.23.1):
     - React-Core
-  - RNRudderSdk (1.12.1):
+  - RNRudderSdk (1.13.0):
     - React
-    - Rudder (< 2.0.0, >= 1.26.0)
+    - Rudder (< 2.0.0, >= 1.26.3)
   - RNSVG (14.1.0):
     - React-Core
   - RSCrashReporter (1.0.1)
-  - Rudder (1.26.1):
+  - Rudder (1.26.3):
     - MetricsReporter (= 1.2.1)
   - Rudder-Amplitude (1.1.1):
     - Amplitude (= 8.16.0)
@@ -1251,7 +1251,7 @@ PODS:
   - Rudder-AppCenter (1.0.1):
     - AppCenter
     - Rudder
-  - Rudder-Appsflyer (2.5.0):
+  - Rudder-Appsflyer (2.6.0):
     - AppsFlyerFramework (~> 6.12)
     - Rudder (~> 1.12)
   - Rudder-Braze (2.0.0):
@@ -1263,43 +1263,43 @@ PODS:
   - Rudder-Firebase (3.3.0):
     - FirebaseAnalytics (~> 10.21.0)
     - Rudder (~> 1.25)
-  - rudder-integration-amplitude-react-native (1.0.9):
+  - rudder-integration-amplitude-react-native (1.1.0):
     - React
     - RNRudderSdk
     - Rudder-Amplitude
-  - rudder-integration-appcenter-react-native (1.0.10):
+  - rudder-integration-appcenter-react-native (1.1.0):
     - React
     - RNRudderSdk
     - Rudder-AppCenter
-  - rudder-integration-appsflyer-react-native (1.5.9):
+  - rudder-integration-appsflyer-react-native (1.6.0):
     - React
     - RNRudderSdk
     - Rudder-Appsflyer (>= 2.2.0)
-  - rudder-integration-braze-react-native (1.2.0):
+  - rudder-integration-braze-react-native (1.3.0):
     - React
     - RNRudderSdk
     - Rudder-Braze (~> 2.0)
-  - rudder-integration-clevertap-react-native (1.0.12):
+  - rudder-integration-clevertap-react-native (1.1.0):
     - CleverTap-iOS-SDK
     - React
     - RNRudderSdk
     - Rudder-CleverTap (~> 1.1.2)
-  - rudder-integration-firebase-react-native (1.0.19):
+  - rudder-integration-firebase-react-native (1.1.0):
     - React
     - RNRudderSdk
     - Rudder-Firebase (~> 3.1)
-  - rudder-integration-moengage-react-native (1.0.9):
+  - rudder-integration-moengage-react-native (1.1.0):
     - React
     - RNRudderSdk
     - Rudder-Moengage
-  - rudder-integration-singular-react-native (1.0.9):
+  - rudder-integration-singular-react-native (1.1.0):
     - React
     - RNRudderSdk
     - Rudder-Singular
   - Rudder-Moengage (2.1.1):
     - MoEngage-iOS-SDK (~> 9.5)
     - Rudder (~> 1.12)
-  - rudder-plugin-db-encryption-react-native (1.0.3):
+  - rudder-plugin-db-encryption-react-native (1.1.0):
     - React
     - RNRudderSdk
     - Rudder (< 2.0.0, >= 1.24.1)
@@ -1592,7 +1592,7 @@ SPEC CHECKSUMS:
   Amplitude: 4daad8eb8193b15353221dfd96c52220367cb3e8
   AnalyticsConnector: a53214d38ae22734c6266106c0492b37832633a9
   AppCenter: 85c92db0759d2792a65eb61d6842d2e86611a49a
-  AppsFlyerFramework: 39efd4d2523ca9e3234805aea0c6b3c3a4a387d1
+  AppsFlyerFramework: b3de9a49c6af8a8e38c44603e468b5e207f22466
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   BrazeKit: 55dfadd08105765a568137f5d24d46894186db65
   CleverTap-iOS-SDK: 36c21b8a671d87a0f9c7b389b339d02528bbe4d7
@@ -1601,9 +1601,9 @@ SPEC CHECKSUMS:
   FBLazyVector: fbc4957d9aa695250b55d879c1d86f79d7e69ab4
   FBReactNativeSpec: 90867cab63f0ca6568f7bf53e880178c8d229457
   FirebaseAnalytics: d275f288881d4417f780115dd52c05fa9752d530
-  FirebaseCore: c43f9f0437b50a965e930cac4ad243200d12a984
-  FirebaseCoreInternal: 6a292e6f0bece1243a737e81556e56e5e19282e3
-  FirebaseInstallations: 42d6ead4605d6eafb3b6683674e80e18eb6f2c35
+  FirebaseCore: 11dc8a16dfb7c5e3c3f45ba0e191a33ac4f50894
+  FirebaseCoreInternal: bcb5acffd4ea05e12a783ecf835f2210ce3dc6af
+  FirebaseInstallations: 8f581fca6478a50705d2bd2abd66d306e0f5736e
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -1666,26 +1666,26 @@ SPEC CHECKSUMS:
   React-utils: f5bc61e7ea3325c0732ae2d755f4441940163b85
   ReactCommon: 45b5d4f784e869c44a6f5a8fad5b114ca8f78c53
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
-  RNRudderSdk: 00779f57dd947c095fd7b8871fd4fc9e4d58a3a0
+  RNRudderSdk: c27e1d1cc0bf152b860f9bf5e5d75826102f24bb
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 5d5e5c1dd738fd6428384afdce40f045a61bcaf7
+  Rudder: 23456f79749849870e18c45bd250d6e2229a7147
   Rudder-Amplitude: a353ca07ba381d23ae587f2f74ea79a6c1563145
   Rudder-AppCenter: 9eca9241e3707a0e9610714dd91dc8da4bae7e1f
-  Rudder-Appsflyer: 63ce2dcea82fac0d0dda654289715048a784839e
+  Rudder-Appsflyer: 4a25dc0339185d2d7c89f8455d946f7bdb359036
   Rudder-Braze: 906ac557204d42bfd29bbf48741d8f6beb9ca2be
   Rudder-CleverTap: a0085aab472e0e60930c4301ef80bae5ff187e98
   Rudder-Firebase: 8bb9a44cbc29ae066c0ada544b242199681547b9
-  rudder-integration-amplitude-react-native: cb6466c434383514779e924c96f60874bfe52e2f
-  rudder-integration-appcenter-react-native: d62990c1d82c297bb271ae11f224c335c62aa6e2
-  rudder-integration-appsflyer-react-native: 7215083a0d8166b284b74d741da5f50eb95aac7d
-  rudder-integration-braze-react-native: 1a4fb3686faf53cc112f109ae6ee3a650ee5b5b2
-  rudder-integration-clevertap-react-native: a3bb4b1eb0b91b39d17ce8758bf30f89eea28976
-  rudder-integration-firebase-react-native: 306aa4b1d304d7c48528a696319ef69e2e6fcb76
-  rudder-integration-moengage-react-native: c6ee8049aac3ed165d2daadd3dfce7c7169b5565
-  rudder-integration-singular-react-native: 0951cfcd9651594cacca052c685c0dc6945997e1
+  rudder-integration-amplitude-react-native: a9896aaef79714931f0edbd40f3cde602b429273
+  rudder-integration-appcenter-react-native: 9cb3ddc2b95cd45232d29b883d58647cff5cd016
+  rudder-integration-appsflyer-react-native: e38621ba25261d71ed26838b105e67fe5c64a406
+  rudder-integration-braze-react-native: 237e030490811fa7eb3192e2800feb6e6d141bca
+  rudder-integration-clevertap-react-native: 3c640ce986bd66996a2e53ff415159dfca0f5c4d
+  rudder-integration-firebase-react-native: 49cdc474a8273432a8b363e966b27dda1a696dea
+  rudder-integration-moengage-react-native: a88e92d14c27edfb1d7c3d27cf2498e4d82cd36d
+  rudder-integration-singular-react-native: 52137a0c399ad1329b53bfe9e8af0a78e11168a3
   Rudder-Moengage: c30465e23740673495ff853eed607a5641f22c5c
-  rudder-plugin-db-encryption-react-native: 300621ba2b3619e9547ea90fe904979b78934026
+  rudder-plugin-db-encryption-react-native: ee8e2ff2a619e2a27656af46b8471048a0a02f10
   Rudder-Singular: e22a4101ce043aded86b777bea873bf6a2af42b9
   RudderDatabaseEncryption: 95b436538412958eda771f5d81bd970a9ffe4eec
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
@@ -1695,6 +1695,6 @@ SPEC CHECKSUMS:
   SQLCipher: 838309284f29953a28ad2e81d87d55ea6b7c74fd
   Yoga: 13c8ef87792450193e117976337b8527b49e8c03
 
-PODFILE CHECKSUM: b6f0e0ea06418274c21420e9a0479fb1eda9c194
+PODFILE CHECKSUM: 0e13a7e6e168462ceda742194047ed5c87c7bf7b
 
 COCOAPODS: 1.14.3

--- a/libs/sdk/RNRudderSdk.podspec
+++ b/libs/sdk/RNRudderSdk.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '11.0'
 
   s.dependency "React"
-  s.dependency "Rudder", '>= 1.26.0', '< 2.0.0'
+  s.dependency "Rudder", '>= 1.26.3', '< 2.0.0'
 end
 
 


### PR DESCRIPTION
## Description of the change

- We have updated the minimum iOS SDK version in the React Native SDK to `v1.26.3` to address the following issue:
> We've decided to remove the tracking domain URL from the Privacy Manifest file. This change aims to resolve the error that occurs when a request to our tracking domain gets blocked after the user denies tracking permission.
Refer to this PR: https://github.com/rudderlabs/rudder-sdk-ios/pull/509.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
