### PR TITLE
feat: use the sqlcipher-android library in db encryption android plugin

### DIFF
--- a/.github/workflows/build-ios-checks.yml
+++ b/.github/workflows/build-ios-checks.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1
         with:
-          version: 1.14.3
+          version: 1.15.2
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/build-ios-checks.yml
+++ b/.github/workflows/build-ios-checks.yml
@@ -26,7 +26,9 @@ jobs:
           ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
-        uses: NiftyStack/install-cocoapods-action@1.0.1
+        uses: maxim-lobanov/setup-cocoapods@v1
+        with:
+          version: 1.14.3
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/build-ios-checks.yml
+++ b/.github/workflows/build-ios-checks.yml
@@ -24,9 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
 
       - name: Setup CocoaPods
-        uses: maxim-lobanov/setup-cocoapods@v1
-        with:
-          version: 1.14.3
+        uses: NiftyStack/install-cocoapods-action@1.0.1
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/build-ios-checks.yml
+++ b/.github/workflows/build-ios-checks.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: NiftyStack/install-cocoapods-action@1.0.1

--- a/.github/workflows/build-ios-checks.yml
+++ b/.github/workflows/build-ios-checks.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1

--- a/.github/workflows/check-compatibility-of-native-sdks.yml
+++ b/.github/workflows/check-compatibility-of-native-sdks.yml
@@ -147,8 +147,6 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1
@@ -238,8 +236,6 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1
@@ -329,8 +325,6 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1
@@ -420,8 +414,6 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1

--- a/.github/workflows/check-compatibility-of-native-sdks.yml
+++ b/.github/workflows/check-compatibility-of-native-sdks.yml
@@ -147,6 +147,8 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: NiftyStack/install-cocoapods-action@1.0.1
@@ -234,6 +236,8 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: NiftyStack/install-cocoapods-action@1.0.1
@@ -321,6 +325,8 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: NiftyStack/install-cocoapods-action@1.0.1
@@ -408,6 +414,8 @@ jobs:
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
         uses: NiftyStack/install-cocoapods-action@1.0.1

--- a/.github/workflows/check-compatibility-of-native-sdks.yml
+++ b/.github/workflows/check-compatibility-of-native-sdks.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1
         with:
-          version: 1.14.3
+          version: 1.15.2
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -240,7 +240,7 @@ jobs:
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1
         with:
-          version: 1.14.3
+          version: 1.15.2
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -329,7 +329,7 @@ jobs:
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1
         with:
-          version: 1.14.3
+          version: 1.15.2
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -418,7 +418,7 @@ jobs:
       - name: Setup CocoaPods
         uses: maxim-lobanov/setup-cocoapods@v1
         with:
-          version: 1.14.3
+          version: 1.15.2
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/check-compatibility-of-native-sdks.yml
+++ b/.github/workflows/check-compatibility-of-native-sdks.yml
@@ -151,7 +151,9 @@ jobs:
           ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
-        uses: NiftyStack/install-cocoapods-action@1.0.1
+        uses: maxim-lobanov/setup-cocoapods@v1
+        with:
+          version: 1.14.3
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -240,7 +242,9 @@ jobs:
           ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
-        uses: NiftyStack/install-cocoapods-action@1.0.1
+        uses: maxim-lobanov/setup-cocoapods@v1
+        with:
+          version: 1.14.3
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -329,7 +333,9 @@ jobs:
           ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
-        uses: NiftyStack/install-cocoapods-action@1.0.1
+        uses: maxim-lobanov/setup-cocoapods@v1
+        with:
+          version: 1.14.3
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -418,7 +424,9 @@ jobs:
           ruby-version: '3.3.2'
 
       - name: Setup CocoaPods
-        uses: NiftyStack/install-cocoapods-action@1.0.1
+        uses: maxim-lobanov/setup-cocoapods@v1
+        with:
+          version: 1.14.3
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/check-compatibility-of-native-sdks.yml
+++ b/.github/workflows/check-compatibility-of-native-sdks.yml
@@ -149,9 +149,7 @@ jobs:
         uses: ruby/setup-ruby@v1
 
       - name: Setup CocoaPods
-        uses: maxim-lobanov/setup-cocoapods@v1
-        with:
-          version: 1.14.3
+        uses: NiftyStack/install-cocoapods-action@1.0.1
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -238,9 +236,7 @@ jobs:
         uses: ruby/setup-ruby@v1
 
       - name: Setup CocoaPods
-        uses: maxim-lobanov/setup-cocoapods@v1
-        with:
-          version: 1.14.3
+        uses: NiftyStack/install-cocoapods-action@1.0.1
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -327,9 +323,7 @@ jobs:
         uses: ruby/setup-ruby@v1
 
       - name: Setup CocoaPods
-        uses: maxim-lobanov/setup-cocoapods@v1
-        with:
-          version: 1.14.3
+        uses: NiftyStack/install-cocoapods-action@1.0.1
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -416,9 +410,7 @@ jobs:
         uses: ruby/setup-ruby@v1
 
       - name: Setup CocoaPods
-        uses: maxim-lobanov/setup-cocoapods@v1
-        with:
-          version: 1.14.3
+        uses: NiftyStack/install-cocoapods-action@1.0.1
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/libs/plugins/rudder-plugin-db-encryption-react-native/android/build.gradle
+++ b/libs/plugins/rudder-plugin-db-encryption-react-native/android/build.gradle
@@ -41,9 +41,9 @@ dependencies {
 
     // rudderstack dependencies
     implementation project(path: ':rudderstack_rudder-sdk-react-native')  // From node_modules
-    implementation 'com.rudderstack.android.sdk:core:[1.20.0, 2.0.0)'
+    implementation 'com.rudderstack.android.sdk:core:[1.24.0, 2.0.0)'
 
     //sql-cipher
-    implementation "net.zetetic:android-database-sqlcipher:4.5.4"
-    implementation "androidx.sqlite:sqlite:2.3.1"
+    implementation "net.zetetic:sqlcipher-android:4.5.6@aar"
+    implementation "androidx.sqlite:sqlite:2.4.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11006,10 +11006,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
     "git-raw-commits": "2.0.11",
     "http-cache-semantics": "4.1.1",
     "dot-prop": "5.3.0",
-    "got": "11.8.6"
+    "got": "11.8.6",
+    "axios": "1.7.4"
   },
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --cache --fix",


### PR DESCRIPTION
## Description of the change

- Provide support for the latest DBEncryption plugin by replacing `net.zetetic:android-database-sqlcipher` with `net.zetetic:sqlcipher-android`. Corresponding changes have already been done on the native Android side since [v1.23.0](https://github.com/rudderlabs/rudder-sdk-android/blob/develop/CHANGELOG.md#1230-2024-05-20).
- Bumped the native Android SDK to the latest version in the DBEncryption Android module.
- Set the Cocopod version to `1.15.2` in `build-ios-checks.yml` and `check-compatibility-of-native-sdks.yml`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
