### PR TITLE
fix: Fix setCustomContext

### DIFF
--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/Utility.java
@@ -160,7 +160,12 @@ public class Utility {
 
     private static void setCustomContext(String key, Map<String, Object> optionsMap, RudderOption options) {
         if (optionsMap.get(key) instanceof Map && !isEmpty(optionsMap.get(key))) {
-            options.putCustomContext(key, (Map<String, Object>) optionsMap.get(key));
+            Map<String, Object> optionsMapContext = (Map<String, Object>) optionsMap.get(key);
+            Map customContext = new HashMap<String, Object>();
+            for (String contextKey : optionsMapContext.keySet()) {
+                customContext.put(contextKey, optionsMapContext.get(contextKey));
+            }
+            options.putCustomContext(key, customContext);
         }
     }
 


### PR DESCRIPTION
## Description of the change

Custom context is not working on Android. I'm passing context per the docs and can trace my data all the way through to where putCustomContext from the Android native SDK is called in Utility.java. However, putCustomContext seems to swallow my data without error. After experimenting I discovered that simply walking over the original map and creating a new map before passing it to `putCustomContext` fixes the issue.

I've created a local patch to unblock my project and thought I'd share the fix here. I wouldn't necessarily recommend accepting this PR until someone with more Java/RudderStack experience can explain why this fix works. If someone can answer that I'll add a code comment to explain why the hijinks are necessary. Otherwise if this is just a mysterious issue in my app then my patch is working and I'll close the PR and move on.

react-native@0.74.5
@rudderstack/rudder-sdk-react-native@1.14.0

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://github.com/rudderlabs/rudder-sdk-react-native/pull/347

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
