### PR TITLE
fix: revert releaseAs set to major in project.json

### DIFF
--- a/libs/rudder-integration-facebook-react-native/project.json
+++ b/libs/rudder-integration-facebook-react-native/project.json
@@ -89,8 +89,7 @@
       "options": {
         "baseBranch": "master",
         "preset": "conventional",
-        "tagPrefix": "{projectName}@",
-        "releaseAs": "major"
+        "tagPrefix": "{projectName}@"
       }
     },
     "github": {


### PR DESCRIPTION
## Description of the change

This will ensure the version bump happens based on the commit types.
It was previously set to `major` to ensure the first release happens as `v1.0.0`. Now we no longer need that.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
