### PR TITLE
feat: add gzip configuration support

### DIFF
--- a/apps/example/ios/Example.xcodeproj/project.pbxproj
+++ b/apps/example/ios/Example.xcodeproj/project.pbxproj
@@ -803,7 +803,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -886,7 +889,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -1296,7 +1296,7 @@ PODS:
     - React-utils (= 0.74.1)
   - RNCAsyncStorage (1.23.1):
     - React-Core
-  - RNRudderSdk (1.14.0):
+  - RNRudderSdk (1.14.1):
     - React
     - Rudder (< 2.0.0, >= 1.26.3)
   - RNSVG (15.3.0):
@@ -1346,7 +1346,7 @@ PODS:
     - React
     - RNRudderSdk
     - Rudder-CleverTap (~> 1.1.2)
-  - rudder-integration-facebook-react-native (1.0.0):
+  - rudder-integration-facebook-react-native (1.0.1):
     - React
     - RNRudderSdk
     - Rudder-Facebook (< 3.0.0, >= 2.2.1)
@@ -1719,7 +1719,7 @@ SPEC CHECKSUMS:
   React-utils: 3285151c9d1e3a28a9586571fc81d521678c196d
   ReactCommon: f42444e384d82ab89184aed5d6f3142748b54768
   RNCAsyncStorage: 826b603ae9c0f88b5ac4e956801f755109fa4d5c
-  RNRudderSdk: 9e243c47f3040a49c559f3b01186fe48e5158c01
+  RNRudderSdk: b31488f3452592107ff3835120a13df4d00e394c
   RNSVG: a48668fd382115bc89761ce291a81c4ca5f2fd2e
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 3cfcd9e6c5359cd6d49f411101ed9b894e3b64bd
@@ -1735,7 +1735,7 @@ SPEC CHECKSUMS:
   rudder-integration-appsflyer-react-native: 393473fd43ee3c792484a36014fcfeae1169abe5
   rudder-integration-braze-react-native: 237e030490811fa7eb3192e2800feb6e6d141bca
   rudder-integration-clevertap-react-native: 3c640ce986bd66996a2e53ff415159dfca0f5c4d
-  rudder-integration-facebook-react-native: 0d3a8e6279b81c39495a81d7badf4c4c8815bd8f
+  rudder-integration-facebook-react-native: 501ddd3441b7e0ede4848b76e184797c10ef8be3
   rudder-integration-firebase-react-native: 49cdc474a8273432a8b363e966b27dda1a696dea
   rudder-integration-moengage-react-native: a88e92d14c27edfb1d7c3d27cf2498e4d82cd36d
   rudder-integration-singular-react-native: 52137a0c399ad1329b53bfe9e8af0a78e11168a3

--- a/apps/example/src/app/App.tsx
+++ b/apps/example/src/app/App.tsx
@@ -104,7 +104,7 @@ const initRudderReactNativeSDK = async () => {
     trackAppLifecycleEvents: true,
     autoSessionTracking: true,
     dbEncryption: dbEncryption,
-    isGzip: true,
+    enableGzip: true,
     withFactories: [
       appsflyer,
       amplitude,

--- a/apps/example/src/app/App.tsx
+++ b/apps/example/src/app/App.tsx
@@ -104,6 +104,7 @@ const initRudderReactNativeSDK = async () => {
     trackAppLifecycleEvents: true,
     autoSessionTracking: true,
     dbEncryption: dbEncryption,
+    isGzip: true,
     withFactories: [
       appsflyer,
       amplitude,

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNParamsConfigurator.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNParamsConfigurator.java
@@ -80,6 +80,9 @@ class RNParamsConfigurator {
         if (config.hasKey("collectDeviceId")) {
             configBuilder.withCollectDeviceId(config.getBoolean("collectDeviceId"));
         }
+        if(config.hasKey("isGzip")) {
+            configBuilder.withGzip(config.getBoolean("isGzip"));
+        }
         return configBuilder;
     }
 

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNParamsConfigurator.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNParamsConfigurator.java
@@ -80,8 +80,8 @@ class RNParamsConfigurator {
         if (config.hasKey("collectDeviceId")) {
             configBuilder.withCollectDeviceId(config.getBoolean("collectDeviceId"));
         }
-        if(config.hasKey("isGzip")) {
-            configBuilder.withGzip(config.getBoolean("isGzip"));
+        if(config.hasKey("enableGzip")) {
+            configBuilder.withGzip(config.getBoolean("enableGzip"));
         }
         return configBuilder;
     }

--- a/libs/sdk/ios/RNParamsConfigurator.m
+++ b/libs/sdk/ios/RNParamsConfigurator.m
@@ -84,6 +84,9 @@
     if ([config objectForKey:@"collectDeviceId"]) {
         [configBuilder withCollectDeviceId:[config[@"collectDeviceId"] boolValue]];
     }
+    if ([config objectForKey:@"isGzip"]) {
+      [configBuilder withGzip:[config[@"isGzip"] boolValue]];
+    }
     return configBuilder;
 }
 

--- a/libs/sdk/ios/RNParamsConfigurator.m
+++ b/libs/sdk/ios/RNParamsConfigurator.m
@@ -84,8 +84,8 @@
     if ([config objectForKey:@"collectDeviceId"]) {
         [configBuilder withCollectDeviceId:[config[@"collectDeviceId"] boolValue]];
     }
-    if ([config objectForKey:@"isGzip"]) {
-      [configBuilder withGzip:[config[@"isGzip"] boolValue]];
+    if ([config objectForKey:@"enableGzip"]) {
+      [configBuilder withGzip:[config[@"enableGzip"] boolValue]];
     }
     return configBuilder;
 }

--- a/libs/sdk/src/Constants.ts
+++ b/libs/sdk/src/Constants.ts
@@ -15,3 +15,4 @@ export const AUTO_SESSION_TRACKING = true;
 export const SESSION_TIMEOUT = 300000;
 export const ENABLE_BACKGROUND_MODE = false;
 export const COLLECT_DEVICE_ID = true;
+export const IS_GZIP = true;

--- a/libs/sdk/src/Constants.ts
+++ b/libs/sdk/src/Constants.ts
@@ -15,4 +15,4 @@ export const AUTO_SESSION_TRACKING = true;
 export const SESSION_TIMEOUT = 300000;
 export const ENABLE_BACKGROUND_MODE = false;
 export const COLLECT_DEVICE_ID = true;
-export const IS_GZIP = true;
+export const ENABLE_GZIP = true;

--- a/libs/sdk/src/NativeBridge.ts
+++ b/libs/sdk/src/NativeBridge.ts
@@ -17,7 +17,7 @@ export interface Configuration {
   sessionTimeout?: number;
   enableBackgroundMode?: boolean;
   collectDeviceId?: boolean;
-  isGzip?: boolean;
+  enableGzip?: boolean;
   dbEncryption?: IDBEncryption;
   // eslint-disable-next-line @typescript-eslint/ban-types
   withFactories?: Array<Record<string, unknown> | Function>;

--- a/libs/sdk/src/NativeBridge.ts
+++ b/libs/sdk/src/NativeBridge.ts
@@ -17,6 +17,7 @@ export interface Configuration {
   sessionTimeout?: number;
   enableBackgroundMode?: boolean;
   collectDeviceId?: boolean;
+  isGzip?: boolean;
   dbEncryption?: IDBEncryption;
   // eslint-disable-next-line @typescript-eslint/ban-types
   withFactories?: Array<Record<string, unknown> | Function>;

--- a/libs/sdk/src/RudderClient.ts
+++ b/libs/sdk/src/RudderClient.ts
@@ -78,6 +78,10 @@ function validateConfiguration(configuration: Configuration) {
     logWarn("setup : 'collectDeviceId' must be a boolean. Falling back to the default value");
     delete configuration.collectDeviceId;
   }
+  if (configuration.isGzip && typeof configuration.isGzip != 'boolean') {
+    logWarn("setup : 'isGzip' must be a boolean. Falling back to the default value");
+    delete configuration.isGzip;
+  }
 }
 
 // setup the RudderSDK with writeKey and Config

--- a/libs/sdk/src/RudderClient.ts
+++ b/libs/sdk/src/RudderClient.ts
@@ -4,7 +4,7 @@ import AsyncLock from 'async-lock';
 import { configure } from './RudderConfiguration';
 import bridge, { Configuration } from './NativeBridge';
 import { logInit, logDebug, logError, logWarn } from './Logger';
-import { SDK_VERSION } from './Constants';
+import { SDK_VERSION, ENABLE_GZIP } from './Constants';
 import IRudderContext from './IRudderContext';
 import { filterNaN } from './FilterNaN';
 
@@ -79,7 +79,9 @@ function validateConfiguration(configuration: Configuration) {
     delete configuration.collectDeviceId;
   }
   if (configuration.enableGzip && typeof configuration.enableGzip != 'boolean') {
-    logWarn("setup : 'enableGzip' must be a boolean. Falling back to the default value");
+    logWarn(
+      `setup : 'enableGzip' must be a boolean. Falling back to the default value ${ENABLE_GZIP}`,
+    );
     delete configuration.enableGzip;
   }
 }

--- a/libs/sdk/src/RudderClient.ts
+++ b/libs/sdk/src/RudderClient.ts
@@ -78,9 +78,9 @@ function validateConfiguration(configuration: Configuration) {
     logWarn("setup : 'collectDeviceId' must be a boolean. Falling back to the default value");
     delete configuration.collectDeviceId;
   }
-  if (configuration.isGzip && typeof configuration.isGzip != 'boolean') {
-    logWarn("setup : 'isGzip' must be a boolean. Falling back to the default value");
-    delete configuration.isGzip;
+  if (configuration.enableGzip && typeof configuration.enableGzip != 'boolean') {
+    logWarn("setup : 'enableGzip' must be a boolean. Falling back to the default value");
+    delete configuration.enableGzip;
   }
 }
 

--- a/libs/sdk/src/RudderClient.ts
+++ b/libs/sdk/src/RudderClient.ts
@@ -78,7 +78,10 @@ function validateConfiguration(configuration: Configuration) {
     logWarn("setup : 'collectDeviceId' must be a boolean. Falling back to the default value");
     delete configuration.collectDeviceId;
   }
-  if (configuration.enableGzip && typeof configuration.enableGzip != 'boolean') {
+  if (
+    typeof configuration.enableGzip !== 'undefined' &&
+    typeof configuration.enableGzip != 'boolean'
+  ) {
     logWarn(
       `setup : 'enableGzip' must be a boolean. Falling back to the default value ${ENABLE_GZIP}`,
     );

--- a/libs/sdk/src/RudderConfiguration.ts
+++ b/libs/sdk/src/RudderConfiguration.ts
@@ -14,6 +14,7 @@ import {
   SESSION_TIMEOUT,
   ENABLE_BACKGROUND_MODE,
   COLLECT_DEVICE_ID,
+  IS_GZIP,
 } from './Constants';
 
 export const configure = async (
@@ -33,6 +34,7 @@ export const configure = async (
     trackAppLifecycleEvents = TRACK_LIFECYCLE_EVENTS,
     recordScreenViews = RECORD_SCREEN_VIEWS,
     collectDeviceId = COLLECT_DEVICE_ID,
+    isGzip = IS_GZIP,
     dbEncryption,
     withFactories = [],
   }: Configuration,
@@ -68,6 +70,7 @@ export const configure = async (
     enableBackgroundMode,
     recordScreenViews,
     collectDeviceId,
+    isGzip,
   };
 
   return config;

--- a/libs/sdk/src/RudderConfiguration.ts
+++ b/libs/sdk/src/RudderConfiguration.ts
@@ -14,7 +14,7 @@ import {
   SESSION_TIMEOUT,
   ENABLE_BACKGROUND_MODE,
   COLLECT_DEVICE_ID,
-  IS_GZIP,
+  ENABLE_GZIP,
 } from './Constants';
 
 export const configure = async (
@@ -34,7 +34,7 @@ export const configure = async (
     trackAppLifecycleEvents = TRACK_LIFECYCLE_EVENTS,
     recordScreenViews = RECORD_SCREEN_VIEWS,
     collectDeviceId = COLLECT_DEVICE_ID,
-    isGzip = IS_GZIP,
+    enableGzip = ENABLE_GZIP,
     dbEncryption,
     withFactories = [],
   }: Configuration,
@@ -70,7 +70,7 @@ export const configure = async (
     enableBackgroundMode,
     recordScreenViews,
     collectDeviceId,
-    isGzip,
+    enableGzip,
   };
 
   return config;


### PR DESCRIPTION
## Description of the change

- In this PR, we added the GZIP configuration support in React Native SDK.
- User can now enable or disbale GZIP by setting `isGzip` to true/false while SDK init:
```
const config = {
    dataPlaneUrl: TEST_DATAPLANE_URL,
    isGzip: false,
  };
  await rc.setup(TEST_WRITE_KEY, config, options);
```
- By default, GZIP will be enabled.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
