### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          repositories: rudder-sdk-react-native
           permission-contents: write # to create commits, tags, and releases
           permission-pull-requests: write # to create and update PRs
 

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -93,19 +93,32 @@ jobs:
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           git fetch --no-tags --prune --depth=100 origin master
-          npm run release
+          npm run release -- --skip.commit --skip.tag
           ./scripts/sync-tags-in-nx-projects.sh
           ./scripts/generate-last-release-changelog.sh
           ./scripts/update-rn-sdk-version-in-constants-file.sh
           npm run bump-version:monorepo
           npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE sonar-project.properties
           npm i
-          git add .
-          git commit -m "chore: sync versions and generate release logs"
 
-      - name: Push new versions in release branch
+      - name: Get list of changed files
+        id: changed-files
         run: |
-          git push --follow-tags
+          # Get all changed files and format them for the signed commit action
+          changed_files=$(git diff --name-only | tr '\n' '\n')
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$changed_files" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore: sync versions and generate release logs'
+          files: ${{ steps.changed-files.outputs.files }}
+          tag: 'v${{ steps.create-release.outputs.new_version }}'
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -46,13 +46,6 @@ jobs:
         run: |
           npm run setup:ci
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
         id: create-release
@@ -77,14 +70,22 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
+
+      - name: Create release branch via API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version
         id: finish-release

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read # GITHUB_TOKEN only needs read access, App Token handles all write operations
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/develop') || startsWith(github.ref, 'refs/heads/hotfix/')
@@ -19,10 +19,20 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
@@ -102,7 +112,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: 'chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master'
           pr_body: ':crown: *An automated PR*'
           pr_reviewer: '@rudderlabs/sdk-rn'

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -81,11 +81,13 @@ jobs:
       - name: Create release branch via API
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BRANCH_NAME: ${{ steps.create-release.outputs.branch_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           BASE_SHA=$(git rev-parse HEAD)
-          gh api repos/${{ github.repository }}/git/refs \
+          gh api "repos/$REPOSITORY/git/refs" \
             --method POST \
-            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f ref="refs/heads/$BRANCH_NAME" \
             -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          repositories: rudder-sdk-react-native
           permission-contents: write # to create commits, tags, and releases
           permission-pull-requests: write # to create and update PRs
 

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -12,6 +12,8 @@ permissions:
 
 jobs:
   release:
+    permissions:
+      contents: read # GITHUB_TOKEN only needs read access, App Token handles all write operations
     name: Publish new release
     runs-on: ubuntu-latest
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
@@ -20,6 +22,15 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+          permission-pull-requests: write # to create and update PRs
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -35,6 +46,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Get the latest version tag
         id: extract-previous-version
@@ -97,7 +109,7 @@ jobs:
         with:
           source_branch: 'master'
           destination_branch: 'develop'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: 'chore(release): pulling master into develop post release v${{ steps.extract-version.outputs.release_version }}'
           pr_body: ':crown: *An automated PR*'
           pr_reviewer: '@rudderlabs/sdk-rn'

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -80,13 +80,15 @@ jobs:
       - name: Create Monorepo Release Tag via API
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           # Get the commit SHA of HEAD on master
           COMMIT_SHA=$(git rev-parse HEAD)
           # Create lightweight tag via GitHub API (tags created via API are shown as verified)
-          gh api repos/${{ github.repository }}/git/refs \
+          gh api "repos/$REPOSITORY/git/refs" \
             --method POST \
-            -f ref="refs/tags/v${{ steps.extract-version.outputs.release_version }}" \
+            -f ref="refs/tags/v$RELEASE_VERSION" \
             -f sha="$COMMIT_SHA"
 
       - name: Get the two latest versions

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -76,13 +76,17 @@ jobs:
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
 
-      - name: Create Monorepo Release Tag
-        id: create_monorepo_release
+      - name: Create Monorepo Release Tag via API
         env:
-          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git tag -a "v${RELEASE_VERSION}" -m "chore: release v${RELEASE_VERSION}"
-          git push origin "refs/tags/v${RELEASE_VERSION}"
+          # Get the commit SHA of HEAD on master
+          COMMIT_SHA=$(git rev-parse HEAD)
+          # Create lightweight tag via GitHub API (tags created via API are shown as verified)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/tags/v${{ steps.extract-version.outputs.release_version }}" \
+            -f sha="$COMMIT_SHA"
 
       - name: Get the two latest versions
         run: |


### PR DESCRIPTION
## Summary
Migrates all PAT usages in GitHub Actions workflows to either GITHUB_TOKEN or GitHub App Token, following security best practices and ensuring PRs trigger CI checks.

**Key insight:** Git push with ANY token (PAT, GITHUB_TOKEN, or App Token) does NOT create verified commits. This PR uses `ryancyq/github-signed-commit` action and GitHub API to ensure all automated commits are verified.

### Files Changed
- `.github/workflows/notion-pr-sync.yml` - Migrated to GITHUB_TOKEN
- `.github/workflows/draft-new-release.yml` - Migrated to GitHub App Token + signed commits (simplified)
- `.github/workflows/publish-new-release.yml` - Migrated to GitHub App Token + API tag creation
- `.github/workflows/update-minimum-android-and-ios-sdk.yml` - Migrated to GitHub App Token + signed commits

### Migration Pattern Evolution

This PR implements the **new simplified pattern** for release workflows:

1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

**What was removed from draft-new-release.yml:**
- ❌ `git config user.name/email` steps (signed commit uses App identity)
- ❌ `git push --set-upstream origin` (replaced with GitHub API branch creation)
- ❌ `git checkout -b` (branch created directly on remote via API)

**What was added:**
- ✅ `gh api repos/.../git/refs` to create branch via API
- ✅ `--skip.commit --skip.tag` flags to standard-version
- ✅ `ryancyq/github-signed-commit` for verified commits

### Migration Details

| File | Token Type | Signed Commits | Changes |
|------|------------|----------------|---------|
| notion-pr-sync.yml | GITHUB_TOKEN | N/A | Only reads PR metadata for Notion sync |
| draft-new-release.yml | GitHub App Token | Yes | Replaced `git add/commit/push` with `ryancyq/github-signed-commit` + API branch creation |
| publish-new-release.yml | GitHub App Token | N/A (tag only) | Replaced `git tag/push` with GitHub API for tag creation |
| update-minimum-android-and-ios-sdk.yml | GitHub App Token | Yes | Replaced `git add/commit/push` with `ryancyq/github-signed-commit` |

### Key Changes
- **Verified commits**: Use `ryancyq/github-signed-commit@v1.2.0` action to create commits via GitHub API
- **Verified tags**: Use GitHub API (`gh api`) to create tags instead of `git push`
- **Job-level permissions**: Added explicit permissions at job level with comments
- **App Token generation**: Generate token early (before checkout) for workflows that need to trigger other workflows
- **Checkout with token**: Pass App Token to `actions/checkout` via `token:` parameter
- **Template injection fix**: Fixed template-injection vulnerabilities in `update-minimum-android-and-ios-sdk.yml` by using environment variables
- **Simplified pattern**: Removed unnecessary git config and push commands in favor of API-based operations

### Security Improvements
- Follows principle of least privilege - each job only gets the permissions it needs
- Eliminates use of PAT (Personal Access Token) which has broad, user-level permissions
- Uses GitHub App tokens with fine-grained, scoped permissions
- All automated commits will now be verified (shown as "Verified" on GitHub)
- Fixed template-injection issues in `update-minimum-android-and-ios-sdk.yml`

## Test plan
- [ ] Verify notion-pr-sync workflow runs successfully on next PR event
- [ ] Verify draft-new-release workflow can create PRs with verified commits that trigger CI
- [ ] Verify publish-new-release workflow can create verified tags and PRs
- [ ] Verify update-minimum-android-and-ios-sdk workflow can create PRs with verified commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)