### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # What is RudderStack?
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-react-native)
+
 [RudderStack](https://rudderstack.com/) is a **customer data pipeline** tool for collecting, routing and processing data from your websites, apps, cloud tools, and data warehouse.
 
 More information on RudderStack can be found [here](https://github.com/rudderlabs/rudder-server).


### PR DESCRIPTION
## Description

Add a [DeepWiki](https://deepwiki.com) badge to the top of the README. The badge links to the DeepWiki page for this repository (`https://deepwiki.com/rudderlabs/rudder-sdk-react-native`), providing quick access to AI-generated documentation and codebase understanding.

## Changes

- Added the DeepWiki badge (SVG) to `README.md`, placed right below the main heading.

## Testing

- Visual inspection of the badge rendering in the GitHub README preview.
