### PR TITLE
chore(vuln): remediate template-injection findings (SEC-251)

### DIFF
--- a/.github/workflows/check-compatibility-of-native-sdks.yml
+++ b/.github/workflows/check-compatibility-of-native-sdks.yml
@@ -82,8 +82,10 @@ jobs:
 
       - name: Update beta Android SDK version in integrations and SDK packages build.gradle file
         if: github.event.inputs.is_android_beta_version == 'true'
+        env:
+          ANDROID_VERSION: ${{ github.event.inputs.android_version }}
         run: |
-          BETA__VERSION='${{ github.event.inputs.android_version }}'
+          BETA__VERSION="$ANDROID_VERSION"
 
           for dir in "libs"/*; do
             if [ "$dir" == "libs/plugins" ]; then
@@ -95,8 +97,10 @@ jobs:
 
       - name: Update Released Android SDK version in integrations and SDK packages build.gradle file
         if: github.event.inputs.is_android_beta_version == 'false'
+        env:
+          ANDROID_VERSION: ${{ github.event.inputs.android_version }}
         run: |
-          MINIMUM_VERSION='${{ github.event.inputs.android_version }}'
+          MINIMUM_VERSION="$ANDROID_VERSION"
 
           for dir in "libs"/*; do
             if [ "$dir" == "libs/plugins" ]; then
@@ -150,10 +154,12 @@ jobs:
           mv Podfile.tmp Podfile
 
       - name: Add Rudder pod in Podfile
+        env:
+          IOS_VERSION: ${{ github.event.inputs.ios_version }}
         run: |
           cd apps/example/ios
           sed -i '' -e "/target 'Example' do/a\\
-            pod 'Rudder', '${{ github.event.inputs.ios_version }}'" Podfile
+            pod 'Rudder', '$IOS_VERSION'" Podfile
 
       - name: Display Podfile
         run: cat apps/example/ios/Podfile
@@ -230,10 +236,12 @@ jobs:
           mv Podfile.tmp Podfile
 
       - name: Add Rudder pod in Podfile
+        env:
+          IOS_VERSION: ${{ github.event.inputs.ios_version }}
         run: |
           cd apps/example/ios
           sed -i '' -e "/target 'Example' do/a\\
-            pod 'Rudder', '${{ github.event.inputs.ios_version }}'" Podfile
+            pod 'Rudder', '$IOS_VERSION'" Podfile
 
       - name: Add use_frameworks! in Podfile
         run: |
@@ -324,10 +332,12 @@ jobs:
           mv Podfile.tmp Podfile
 
       - name: Add Rudder pod in Podfile
+        env:
+          IOS_VERSION: ${{ github.event.inputs.ios_version }}
         run: |
           cd apps/example/ios
           sed -i '' -e "/target 'Example' do/a\\
-            pod 'Rudder', '${{ github.event.inputs.ios_version }}'" Podfile
+            pod 'Rudder', '$IOS_VERSION'" Podfile
 
       - name: Add use_frameworks! :linkage=> :static in Podfile
         run: |
@@ -418,10 +428,12 @@ jobs:
           mv Podfile.tmp Podfile
 
       - name: Add Rudder pod in Podfile
+        env:
+          IOS_VERSION: ${{ github.event.inputs.ios_version }}
         run: |
           cd apps/example/ios
           sed -i '' -e "/target 'Example' do/a\\
-            pod 'Rudder', '${{ github.event.inputs.ios_version }}'" Podfile
+            pod 'Rudder', '$IOS_VERSION'" Podfile
 
       - name: Add use_frameworks! :linkage => :dynamic in Podfile
         run: |

--- a/.github/workflows/update-minimum-android-and-ios-sdk.yml
+++ b/.github/workflows/update-minimum-android-and-ios-sdk.yml
@@ -53,16 +53,20 @@ jobs:
 
       - name: Update Android SDK Version
         if: github.event.inputs.android_minimum_version != ''
+        env:
+          ANDROID_MIN_VER: ${{ github.event.inputs.android_minimum_version }}
         run: |
-          minimum_version='${{ github.event.inputs.android_minimum_version }}'
+          minimum_version="$ANDROID_MIN_VER"
           sed -i "s/com.rudderstack.android.sdk:core:\[[0-9.]*,[0-9]*/com.rudderstack.android.sdk:core:\[$minimum_version,/" libs/sdk/android/build.gradle
           git add .
           git commit -m "fix(rudder-sdk-react-native): update minimum Android SDK versions"
 
       - name: Update iOS SDK Version
         if: github.event.inputs.ios_minimum_version != ''
+        env:
+          IOS_MIN_VER: ${{ github.event.inputs.ios_minimum_version }}
         run: |
-          minimum_version='${{ github.event.inputs.ios_minimum_version }}'
+          minimum_version="$IOS_MIN_VER"
           sed -i "s/\"Rudder\", '[>= ]*[0-9.]*[0-9]*/\"Rudder\", '>= $minimum_version/" libs/sdk/RNRudderSdk.podspec
           git add .
           git commit -m "fix(rudder-sdk-react-native): update minimum iOS SDK versions"


### PR DESCRIPTION
Remediates \`zizmor/template-injection\` findings in this repo as part of the org-wide remediation tracked in [SEC-251](https://linear.app/rudderstack/issue/SEC-251) (parent: [SEC-162](https://linear.app/rudderstack/issue/SEC-162)).

## Verification

- actionlint (syntax+expressions): green before, green after
- zizmor: all targeted findings absent post-fix; no new findings introduced
- Edits scoped to `.github/` only; no reformatting / drive-by changes

## Test plan

- [ ] CI green
- [ ] No release-tagging or workflow-trigger regression (SEC-198 class)