### PR TITLE
fix(sprig): remove releaseAs major override from version target

### DIFF
--- a/libs/rudder-integration-sprig-react-native/project.json
+++ b/libs/rudder-integration-sprig-react-native/project.json
@@ -93,12 +93,7 @@
       "options": {
         "baseBranch": "master",
         "preset": "conventional",
-        "tagPrefix": "{projectName}@",
-        // TODO: REMOVE after the first 1.0.0 release ships. @jscutlery/semver is
-        // tag-based and falls back to 0.0.0 when no prior tag exists; this forces
-        // 0.0.0 -> 1.0.0 on the first release. If left in, every subsequent release
-        // will be a forced major bump (1.0.0 -> 2.0.0 -> 3.0.0 ...).
-        "releaseAs": "major"
+        "tagPrefix": "{projectName}@"
       }
     },
     "github": {


### PR DESCRIPTION
## Description

Removes the `"releaseAs": "major"` override (and its accompanying TODO comment) from the `version` target in `libs/rudder-integration-sprig-react-native/project.json`.

This override was a one-time bootstrap hack to force the Sprig integration's first release to `1.0.0` instead of `0.1.0`. `@jscutlery/semver:version` is tag-based — without a prior tag matching `tagPrefix`, it seeds at `0.0.0` and conventional commits would have emitted `0.1.0` from the initial `feat:` commits. The override pushed that first release to `1.0.0`.

Now that Sprig `1.0.0` has shipped and the tag `rudder-integration-sprig-react-native@1.0.0` exists, the override must be removed. If left in place, every future release would read the existing tag and be forced into an unintended **major** bump (`1.0.0 → 2.0.0 → 3.0.0 …`) regardless of commit type — a silent failure mode that CI does not catch.

After this change, the `version` target matches all sibling integrations (amplitude, braze, etc.) and follows standard conventional-commits versioning (`feat:` → minor, `fix:` → patch, `BREAKING CHANGE:` → major).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Removed the `"releaseAs": "major"` option from the `version` target in `libs/rudder-integration-sprig-react-native/project.json`.
- Removed the associated `TODO: REMOVE after the first 1.0.0 release ships` comment block.
- Restored the trailing structure (dropped the now-redundant comma after `tagPrefix`) so the target shape matches sibling integrations.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [x] I have updated the changelog (if required).

## How to test?
On a branch containing a `feat:` commit scoped to `rudder-integration-sprig-react-native`, run the version target in dry-run mode:

```bash
npx nx affected --target=version --base=origin/develop --head=HEAD --dry-run
```

Expected: the computed bump is `1.0.0 → 1.1.0` (minor), **not** `1.0.0 → 2.0.0` (major).

Validation already performed locally:
- `nx show project rudder-integration-sprig-react-native --json` parses the config and confirms `releaseAs` is no longer present in the `version` target options.
- The `version` target now matches `libs/rudder-integration-amplitude-react-native/project.json`.

## Breaking Changes
None. This only corrects future release versioning behavior; no runtime or public API change.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
Resolves [SDK-4960](https://linear.app/rudderstack/issue/SDK-4960/remove-releaseas-major-hack-from-sprig-integration-projectjson-post). Parent: SDK-4952.
