### PR TITLE
fix(SDK-4862): add async-lock type declarations to SDK package

### DIFF
--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -29,6 +29,7 @@
   },
   "react-native": "./src/index.ts",
   "dependencies": {
+    "@types/async-lock": "1.4.2",
     "async-lock": "1.4.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,7 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
+        "@types/async-lock": "1.4.2",
         "async-lock": "1.4.0"
       },
       "peerDependencies": {
@@ -10670,7 +10671,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
       "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {


### PR DESCRIPTION
## Summary
- Add `@types/async-lock` to the published SDK package dependencies.
- Ensure consumers get declarations for the shipped `async-lock` import in `src/RudderClient.ts`.

📝 Note: This is intentionally a `dependencies` entry rather than `devDependencies`, because consumers type-check the SDK’s published `src/*.ts` files and need the declaration package installed transitively.

## Root cause
The published React Native SDK package ships raw `src/*.ts` files, and `index.esm.d.ts` re-exports `./src/index`. With strict TypeScript/moduleResolution setups, consumers resolve into `src/RudderClient.ts`, which imports `async-lock`.

`async-lock` does not publish its own types, and `@types/async-lock` was only installed as a monorepo devDependency, so consumer projects can fail with `TS7016` and an implicit `any` on the lock callback.

## Validation
- `npx nx run rudder-sdk-react-native:type-check`
- `npx nx build rudder-sdk-react-native`
- Packed the local SDK and verified a TypeScript 6.0.3 consumer compiles without installing `@types/async-lock` directly.

Fixes SDK-4862
Related to rudderlabs/rudder-sdk-react-native#620