### PR TITLE
fix(android): track app lifecycle at process level

### DIFF
--- a/libs/sdk/android/build.gradle
+++ b/libs/sdk/android/build.gradle
@@ -78,6 +78,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.google.code.gson:gson:2.13.1'
   implementation 'com.rudderstack.android.sdk:core:[1.26.0, 2.0.0)'
+  implementation 'androidx.lifecycle:lifecycle-process:2.6.1'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/libs/sdk/android/build.gradle
+++ b/libs/sdk/android/build.gradle
@@ -64,6 +64,12 @@ android {
       }
     }
   }
+
+  testOptions {
+    // Let stubbed android.jar methods (e.g. android.util.Log) return defaults instead of
+    // throwing, so JVM unit tests can run without Robolectric.
+    unitTests.returnDefaultValues = true
+  }
 }
 
 repositories {
@@ -79,6 +85,11 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.13.1'
   implementation 'com.rudderstack.android.sdk:core:[1.26.0, 2.0.0)'
   implementation 'androidx.lifecycle:lifecycle-process:2.6.1'
+
+  // Pure-JVM unit tests (no emulator/Robolectric). MockK's mockkStatic(...) intercepts the
+  // static RudderClient/RNPreferenceManager factory methods.
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'io.mockk:mockk:1.13.13'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNLifeCycleEventListener.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNLifeCycleEventListener.java
@@ -3,6 +3,10 @@ package com.rudderstack.react.android;
 import android.app.Activity;
 import android.app.Application;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+
 import com.facebook.react.bridge.LifecycleEventListener;
 
 import static com.rudderstack.react.android.LifeCycleEvents.executeRunnable;
@@ -11,14 +15,24 @@ import static com.rudderstack.react.android.LifeCycleEvents.ApplicationOpenedRun
 import static com.rudderstack.react.android.LifeCycleEvents.ApplicationBackgroundedRunnable;
 import static com.rudderstack.react.android.LifeCycleEvents.ScreenViewRunnable;
 
-public class RNLifeCycleEventListener implements LifecycleEventListener {
+/**
+ * Tracks application lifecycle (Application Opened / Application Backgrounded) at the PROCESS
+ * level via androidx ProcessLifecycleOwner, mirroring the native rudder-sdk-android
+ * implementation. ProcessLifecycleOwner only transitions on genuine app foreground/background
+ * (it is debounced across activity transitions), so in-app activity changes - e.g. a
+ * third-party SDK popping a consent dialog / paywall / ad Activity over the React host - no
+ * longer produce spurious Application Opened/Backgrounded loops.
+ *
+ * Automatic screen views stay on React Native's host lifecycle (onHostResume), as they need the
+ * current Activity.
+ */
+public class RNLifeCycleEventListener implements LifecycleEventListener, DefaultLifecycleObserver {
 
-    private int noOfActivities;
     private boolean fromBackground = false;
     private final RNUserSessionPlugin userSessionPlugin;
     private final RNRudderSdkModuleImpl instance;
     private final boolean trackLifeCycleEvents;
-    private boolean recordScreenViews;
+    private final boolean recordScreenViews;
 
     RNLifeCycleEventListener(Application application, RNUserSessionPlugin userSessionPlugin, RNRudderSdkModuleImpl instance, boolean trackLifeCycleEvents, boolean recordScreenViews) {
         this.userSessionPlugin = userSessionPlugin;
@@ -29,14 +43,26 @@ public class RNLifeCycleEventListener implements LifecycleEventListener {
         executeRunnable(applicationStatus);
     }
 
+    // ProcessLifecycleOwner: genuine app foreground. Fires once on cold start (adding the
+    // observer replays the already-STARTED state) and again on every real return from background.
+    @Override
+    public void onStart(@NonNull LifecycleOwner owner) {
+        ApplicationOpenedRunnable openedRunnable = new ApplicationOpenedRunnable(fromBackground, this.userSessionPlugin, this.trackLifeCycleEvents);
+        executeRunnable(openedRunnable);
+    }
+
+    // ProcessLifecycleOwner: genuine app background.
+    @Override
+    public void onStop(@NonNull LifecycleOwner owner) {
+        fromBackground = true;
+        ApplicationBackgroundedRunnable backgroundedRunnable = new ApplicationBackgroundedRunnable(this.userSessionPlugin, this.trackLifeCycleEvents);
+        executeRunnable(backgroundedRunnable);
+    }
+
+    // React Native host lifecycle: used only for automatic screen view tracking (needs the
+    // current Activity).
     @Override
     public void onHostResume() {
-        noOfActivities += 1;
-        if (noOfActivities == 1) {
-            // no previous activity present. Application Opened
-            ApplicationOpenedRunnable openedRunnable = new ApplicationOpenedRunnable(fromBackground, this.userSessionPlugin, this.trackLifeCycleEvents);
-            executeRunnable(openedRunnable);
-        }
         Activity activity = this.instance.getCurrentActivityFromReact();
         if (activity != null && activity.getLocalClassName() != null) {
             ScreenViewRunnable screenViewRunnable = new ScreenViewRunnable(activity.getLocalClassName(), this.userSessionPlugin, this.recordScreenViews);
@@ -46,12 +72,6 @@ public class RNLifeCycleEventListener implements LifecycleEventListener {
 
     @Override
     public void onHostPause() {
-        fromBackground = true;
-        noOfActivities -= 1;
-        if (noOfActivities == 0) {
-            ApplicationBackgroundedRunnable backgroundedRunnable = new ApplicationBackgroundedRunnable(this.userSessionPlugin, this.trackLifeCycleEvents);
-            executeRunnable(backgroundedRunnable);
-        }
     }
 
     @Override

--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModuleImpl.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNRudderSdkModuleImpl.java
@@ -2,9 +2,12 @@ package com.rudderstack.react.android;
 
 import android.app.Activity;
 import android.app.Application;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 
 import androidx.annotation.Nullable;
+import androidx.lifecycle.ProcessLifecycleOwner;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -72,7 +75,12 @@ public class RNRudderSdkModuleImpl {
 
             // Track automatic lifecycle and/or screen events
             RNLifeCycleEventListener lifeCycleEventListener = new RNLifeCycleEventListener(this.application, userSessionPlugin, this, configParams.trackLifeCycleEvents, configParams.recordScreenViews);
+            // Screen views stay on RN's host lifecycle (need the current Activity)
             reactContext.addLifecycleEventListener(lifeCycleEventListener);
+            // Application Opened/Backgrounded are tracked at the process level so in-app activity
+            // transitions don't fire spurious events. ProcessLifecycleOwner must be observed on the main thread.
+            new Handler(Looper.getMainLooper()).post(() ->
+                    ProcessLifecycleOwner.get().getLifecycle().addObserver(lifeCycleEventListener));
 
             // RN SDK is initialised
             initialized = true;

--- a/libs/sdk/android/src/test/java/com/rudderstack/react/android/RNLifeCycleEventListenerTest.kt
+++ b/libs/sdk/android/src/test/java/com/rudderstack/react/android/RNLifeCycleEventListenerTest.kt
@@ -15,18 +15,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
-/**
- * Contract test for the lifecycle-event routing established by SDK-5007.
- *
- * It does NOT reproduce the real transient-Activity overlay end to end; it pins down WHICH source
- * each app-lifecycle event is wired to, guarding against the most likely regression: accidentally
- * moving "Application Opened" / "Application Backgrounded" back onto React's host-activity
- * (LifecycleEventListener) callbacks, which is exactly the bug this PR fixes.
- *
- * Pure JVM test (no emulator / Robolectric): the listener constructor's AppVersion path is
- * neutralized because the mocked Application returns a null PackageManager (AppVersion bails out),
- * and RNPreferenceManager / RudderClient are mocked statically via MockK.
- */
 class RNLifeCycleEventListenerTest {
 
     private val applicationOpened = "Application Opened"
@@ -69,7 +57,7 @@ class RNLifeCycleEventListenerTest {
     // --- React host callbacks must NOT emit app lifecycle events ---
 
     @Test
-    fun onHostPause_doesNotEmitApplicationBackgrounded() {
+    fun `given host activity lifecycle, when onHostPause is called, then Application Backgrounded is not emitted`() {
         listener.onHostPause()
 
         verify(exactly = 0) { rudderClient.track(applicationBackgrounded) }
@@ -77,7 +65,7 @@ class RNLifeCycleEventListenerTest {
     }
 
     @Test
-    fun onHostResume_doesNotEmitApplicationOpened() {
+    fun `given host activity lifecycle, when onHostResume is called, then Application Opened is not emitted`() {
         listener.onHostResume()
 
         verify(exactly = 0) { rudderClient.track(applicationOpened, any<RudderProperty>()) }
@@ -86,14 +74,14 @@ class RNLifeCycleEventListenerTest {
     // --- Process lifecycle callbacks MUST emit app lifecycle events ---
 
     @Test
-    fun onStart_emitsApplicationOpened() {
+    fun `given process lifecycle, when onStart is called, then Application Opened is emitted`() {
         listener.onStart(lifecycleOwner)
 
         verify(exactly = 1) { rudderClient.track(applicationOpened, any<RudderProperty>()) }
     }
 
     @Test
-    fun onStop_emitsApplicationBackgrounded() {
+    fun `given process lifecycle, when onStop is called, then Application Backgrounded is emitted`() {
         listener.onStop(lifecycleOwner)
 
         verify(exactly = 1) { rudderClient.track(applicationBackgrounded) }
@@ -102,7 +90,7 @@ class RNLifeCycleEventListenerTest {
     // --- from_background: false on cold start, true after a background round-trip ---
 
     @Test
-    fun applicationOpened_fromBackgroundReflectsBackgroundRoundTrip() {
+    fun `given a background round-trip, when the app is opened, then from_background is false on cold start and true on resume`() {
         val properties = mutableListOf<RudderProperty>()
 
         listener.onStart(lifecycleOwner) // cold start -> from_background = false

--- a/libs/sdk/android/src/test/java/com/rudderstack/react/android/RNLifeCycleEventListenerTest.kt
+++ b/libs/sdk/android/src/test/java/com/rudderstack/react/android/RNLifeCycleEventListenerTest.kt
@@ -1,0 +1,116 @@
+package com.rudderstack.react.android
+
+import android.app.Application
+import androidx.lifecycle.LifecycleOwner
+import com.rudderstack.android.sdk.core.RudderClient
+import com.rudderstack.android.sdk.core.RudderProperty
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Contract test for the lifecycle-event routing established by SDK-5007.
+ *
+ * It does NOT reproduce the real transient-Activity overlay end to end; it pins down WHICH source
+ * each app-lifecycle event is wired to, guarding against the most likely regression: accidentally
+ * moving "Application Opened" / "Application Backgrounded" back onto React's host-activity
+ * (LifecycleEventListener) callbacks, which is exactly the bug this PR fixes.
+ *
+ * Pure JVM test (no emulator / Robolectric): the listener constructor's AppVersion path is
+ * neutralized because the mocked Application returns a null PackageManager (AppVersion bails out),
+ * and RNPreferenceManager / RudderClient are mocked statically via MockK.
+ */
+class RNLifeCycleEventListenerTest {
+
+    private val applicationOpened = "Application Opened"
+    private val applicationBackgrounded = "Application Backgrounded"
+    private val fromBackground = "from_background"
+
+    private lateinit var rudderClient: RudderClient
+    private lateinit var lifecycleOwner: LifecycleOwner
+    private lateinit var listener: RNLifeCycleEventListener
+
+    @Before
+    fun setUp() {
+        mockkStatic(RudderClient::class)
+        rudderClient = mockk(relaxed = true)
+        every { RudderClient.getInstance() } returns rudderClient
+
+        mockkStatic(RNPreferenceManager::class)
+        every { RNPreferenceManager.getInstance(any()) } returns mockk(relaxed = true)
+
+        val application = mockk<Application>()
+        every { application.packageName } returns "com.rudderstack.test"
+        every { application.packageManager } returns null // AppVersion bails out
+
+        val userSessionPlugin = mockk<RNUserSessionPlugin>(relaxed = true)
+        val instance = mockk<RNRudderSdkModuleImpl>(relaxed = true)
+        lifecycleOwner = mockk(relaxed = true)
+
+        listener = RNLifeCycleEventListener(application, userSessionPlugin, instance, true, false)
+
+        // The constructor runs ApplicationStatusRunnable (Installed/Updated handling); discard any
+        // interactions from it so each test asserts only on the callback it exercises.
+        clearMocks(rudderClient, answers = false)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // --- React host callbacks must NOT emit app lifecycle events ---
+
+    @Test
+    fun onHostPause_doesNotEmitApplicationBackgrounded() {
+        listener.onHostPause()
+
+        verify(exactly = 0) { rudderClient.track(applicationBackgrounded) }
+        verify(exactly = 0) { rudderClient.track(applicationBackgrounded, any<RudderProperty>()) }
+    }
+
+    @Test
+    fun onHostResume_doesNotEmitApplicationOpened() {
+        listener.onHostResume()
+
+        verify(exactly = 0) { rudderClient.track(applicationOpened, any<RudderProperty>()) }
+    }
+
+    // --- Process lifecycle callbacks MUST emit app lifecycle events ---
+
+    @Test
+    fun onStart_emitsApplicationOpened() {
+        listener.onStart(lifecycleOwner)
+
+        verify(exactly = 1) { rudderClient.track(applicationOpened, any<RudderProperty>()) }
+    }
+
+    @Test
+    fun onStop_emitsApplicationBackgrounded() {
+        listener.onStop(lifecycleOwner)
+
+        verify(exactly = 1) { rudderClient.track(applicationBackgrounded) }
+    }
+
+    // --- from_background: false on cold start, true after a background round-trip ---
+
+    @Test
+    fun applicationOpened_fromBackgroundReflectsBackgroundRoundTrip() {
+        val properties = mutableListOf<RudderProperty>()
+
+        listener.onStart(lifecycleOwner) // cold start -> from_background = false
+        listener.onStop(lifecycleOwner)  // app goes to background
+        listener.onStart(lifecycleOwner) // return to foreground -> from_background = true
+
+        verify(exactly = 2) { rudderClient.track(applicationOpened, capture(properties)) }
+        assertEquals(false, properties[0].getProperty(fromBackground))
+        assertEquals(true, properties[1].getProperty(fromBackground))
+    }
+}


### PR DESCRIPTION
## Description

On Android, the SDK fired duplicate / looping `Application Backgrounded` and `Application Opened` events even though the app never actually went to the background.

Lifecycle tracking was wired to React Native's host-activity lifecycle (`onHostResume` / `onHostPause` via `LifecycleEventListener`), which fire for the React host activity only. Whenever any other Android Activity is presented over the React host — e.g. a third-party SDK popping a consent dialog, a paywall, an ad activity, or the system collecting the advertising ID — the React host receives `onHostPause` and then `onHostResume` when control returns, and the SDK emitted a spurious `Application Backgrounded` + `Application Opened` pair while the app stayed in the foreground.

The internal `noOfActivities` counter did not mitigate this: it tracked the React host's resume/pause only (toggling 0↔1), not the count of all activities, so a transient overlay drove it to 0 and back to 1 and the loop fired with a perfectly healthy counter. (A `if (noOfActivities > 0)` style guard does not address the root cause.)

This is documented React Native behavior — `onHostResume` / `onHostPause` are defined to fire for the most current (host) activity only. See the KDoc on the `LifecycleEventListener` interface: ["Navigating from Activity A to a non-React Activity B will trigger one event: onHostPause"](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/LifecycleEventListener.kt).

The fix moves `Application Opened` / `Application Backgrounded` tracking off the host-activity lifecycle and onto the process lifecycle (`androidx.lifecycle.ProcessLifecycleOwner`), mirroring what the native `rudder-sdk-android` SDK already does.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- `RNLifeCycleEventListener` now implements `androidx.lifecycle.DefaultLifecycleObserver` in addition to `LifecycleEventListener`.
  - `onStart(LifecycleOwner)` → emits `Application Opened`. Fires once on cold start (adding the observer replays the already-STARTED state) and again on every genuine return from background; `from_background` stays `false` on cold start and `true` on a real return.
  - `onStop(LifecycleOwner)` → emits `Application Backgrounded` and sets `fromBackground = true`.
- Removed the `noOfActivities` counter and the `Application Opened`/`Backgrounded` logic from `onHostResume` / `onHostPause`.
- `onHostResume` now only drives automatic screen-view tracking (which needs the current Activity); `onHostPause` is now a no-op.
- `RNRudderSdkModuleImpl.setup()` registers the listener on `ProcessLifecycleOwner.get().getLifecycle()` via a main-thread `Handler` post (the observer must be added on the main thread); the existing `addLifecycleEventListener` registration is kept for screen views.
- Added the `androidx.lifecycle:lifecycle-process:2.6.1` dependency. `ProcessLifecycleOwner` is stable since lifecycle 2.0 and auto-initializes via its bundled content provider, so no consumer-side `Application` change is required. Gradle resolves to the highest version on the graph (it aligns to the version React Native already pulls transitively), so there is no downgrade/conflict.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

> Note: the RN SDK repo currently has no unit-test harness for the Android module, so this fix is verified on-device (see "How to test?"). The behavior change should be called out in the changelog (see Breaking Changes).

## How to test?
Run the example app on Android with `trackAppLifecycleEvents: true` and watch the SDK logs (`EventRepository: processMessage: eventName: Application Opened/Backgrounded`):

1. **Cold launch** → exactly one `Application Opened` with `from_background: false`.
2. **Transient overlay** — present another Activity over the React host (e.g. a translucent self-finishing test Activity, or a real third-party consent/paywall/ad Activity) and dismiss it → **zero** `Application Opened` / `Application Backgrounded` events; the app stays foreground/TOP throughout (`adb shell dumpsys activity activities | grep topResumedActivity`).
3. **Genuine background → foreground** (press HOME, then reopen) → exactly one `Application Backgrounded` followed by one `Application Opened` with `from_background: true`.
4. Automatic screen-view tracking continues to work as before.

Verified on-device on both the bare-RN example app and the Expo example app; the full sanity matrix (lint, type-check, test, lib builds, Android build + run, iOS build + run, npm audit) passes.

## Breaking Changes
None in terms of API or required setup. Behavior change to note in the changelog: spurious over-firing of `Application Opened` / `Application Backgrounded` from in-app activity overlays (and configuration-change activity recreations such as rotation) stops, so any consumer that was counting that noise will see reduced lifecycle event volume — which is the intended outcome of this fix.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
The fix aligns the React Native SDK's Android lifecycle tracking with the native `rudder-sdk-android` SDK, which already uses `ProcessLifecycleOwner` for `Application Opened` / `Application Backgrounded`. Automatic screen views deliberately remain on the React host lifecycle because they require the current Activity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android foreground/background tracking by shifting application-level “opened/backgrounded” events to process lifecycle callbacks, while keeping screen view tracking tied to the React host lifecycle.
  * Ensured process-level tracking is registered on the main thread for more reliable event timing.
* **Tests**
  * Added JVM unit tests validating which lifecycle callbacks trigger “application opened/backgrounded” events and verifying `from_background` behavior across cold-start → background → foreground.
* **Chores**
  * Updated Android unit test setup to run on the JVM without Robolectric and refreshed related test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->