### PR TITLE
fix: add dummy commit to trigger db-encryption changelog generation

### DIFF
--- a/libs/plugins/rudder-plugin-db-encryption-react-native/src/dbEncryptionPlugin.ts
+++ b/libs/plugins/rudder-plugin-db-encryption-react-native/src/dbEncryptionPlugin.ts
@@ -9,7 +9,7 @@ class DBEncryption implements IDBEncryption {
     this.enable = enable;
   }
 
-  // Add the encryption plugin.
+  // Add the encryption plugin
   async addDBEncryptionPlugin(key: string, enable: boolean): Promise<void> {
     await bridge.setup(key, enable);
   }


### PR DESCRIPTION
## What

A single-character comment toggle in `dbEncryptionPlugin.ts` to force a conventional-commit-eligible (`fix:`) change on the `rudder-plugin-db-encryption-react-native` package.

Mirrors the established pattern from #626 and #583.

## Why

`rudder-plugin-db-encryption-react-native` statically depends on the core RN SDK, so nx marks it **affected** whenever the core SDK module changes. The SDK-5007 fix (#633) changes the core SDK, so db-encryption is pulled into the release's `affected` set — but it has only `chore` commits since `1.6.0`, so `@jscutlery/semver` computes **no version bump**.

That "affected but no new version" state makes the `Publish new release` and `Deploy to npm` steps try to re-release / re-publish the already-existing `1.6.0`, which fails. This is the long-standing nx-affected behaviour (SDK-1489); the dummy `fix:` commit is the established workaround.

## Verification (`nx affected --target=version … --dry-run`)

| Package | Without this commit | With this commit |
| --- | --- | --- |
| `rudder-sdk-react-native` | 3.1.1 | 3.1.1 |
| `rudder-integration-sprig-react-native` | 1.0.1 | 1.0.1 |
| `rudder-plugin-db-encryption-react-native` | 🟢 Nothing changed (release would fail) | 🆕 **1.6.1** |

## Notes

- Must merge into `develop` **before** running the `Draft new release` workflow.
- Commit type is intentionally `fix:` (not `chore`/`docs`, which the release pipeline skips via `--skipCommitTypes=docs,ci,chore`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated a comment’s punctuation for consistency.
  * No user-facing behavior, features, or fixes changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->