### PR TITLE
ci(release): repair release pipeline broken by SEC-58 [SDK-5007]

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -47,6 +47,12 @@ jobs:
         run: |
           npm run setup:ci
 
+      # Git needs an author identity for the merge/version steps below.
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub actions"
+          git config user.email noreply@github.com
+
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
         id: create-release
@@ -122,7 +128,73 @@ jobs:
           branch-name: ${{ steps.create-release.outputs.branch_name }}
           commit-message: 'chore: sync versions and generate release logs'
           files: ${{ steps.changed-files.outputs.files }}
-          tag: 'v${{ steps.create-release.outputs.new_version }}'
+
+      # Create per-package tags (rudder-sdk-react-native@x.y.z, etc.) at the release
+      # branch HEAD for packages whose version changed. The monorepo v<version> tag is
+      # created by publish-new-release.yml instead. Idempotent: skips if the tag already
+      # points at the release SHA, fails if it points elsewhere.
+      - name: Push release tags to release branch HEAD
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BRANCH_NAME: ${{ steps.create-release.outputs.branch_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          git fetch origin "$BRANCH_NAME"
+          git fetch --no-tags origin master
+          release_sha=$(git rev-parse "origin/$BRANCH_NAME")
+          echo "Release branch HEAD: $release_sha"
+
+          for pj in libs/*/project.json libs/plugins/*/project.json; do
+            tag=$(jq -r '.targets.github.options.tag // empty' "$pj")
+            [ -z "$tag" ] && continue
+
+            pkg_dir=$(dirname "$pj")
+            current_version=$(git show "origin/${BRANCH_NAME}:${pkg_dir}/package.json" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
+            prev_version=$(git show "origin/master:${pkg_dir}/package.json" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || echo "")
+
+            if [ -z "$current_version" ]; then
+              echo "::error::Unable to read version for ${pkg_dir}; refusing to tag ${tag}"
+              exit 1
+            fi
+
+            if [ -n "$prev_version" ] && [ "$current_version" = "$prev_version" ]; then
+              echo "Skipping ${tag} — version unchanged vs origin/master"
+              continue
+            fi
+
+            encoded=$(printf '%s' "$tag" | jq -sRr @uri)
+            if existing_ref=$(gh api "repos/${REPO}/git/ref/tags/${encoded}" 2>/dev/null); then
+              existing_type=$(printf '%s' "$existing_ref" | jq -r '.object.type')
+              existing_obj=$(printf '%s' "$existing_ref" | jq -r '.object.sha')
+              if [ "$existing_type" = "tag" ]; then
+                existing_commit=$(gh api "repos/${REPO}/git/tags/${existing_obj}" --jq '.object.sha')
+              else
+                existing_commit="$existing_obj"
+              fi
+              if [ "$existing_commit" = "$release_sha" ]; then
+                echo "Tag ${tag} already points at ${release_sha}, skipping"
+                continue
+              fi
+              echo "::error::Tag ${tag} exists on origin but points at ${existing_commit} (expected ${release_sha})"
+              exit 1
+            fi
+
+            echo "Creating annotated tag ${tag} -> ${release_sha}"
+
+            pkg_scope="${tag%@*}"
+            pkg_version="${tag##*@}"
+
+            tag_obj_sha=$(gh api --method POST "repos/${REPO}/git/tags" \
+              -f "tag=${tag}" \
+              -f "message=chore(${pkg_scope}): release version ${pkg_version}" \
+              -f "object=${release_sha}" \
+              -f "type=commit" \
+              --jq '.sha')
+
+            gh api --method POST "repos/${REPO}/git/refs" \
+              -f "ref=refs/tags/${tag}" \
+              -f "sha=${tag_obj_sha}"
+          done
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -77,19 +77,43 @@ jobs:
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
 
+      # Sole creator of the monorepo v<version> tag (draft only creates per-package tags).
+      # Idempotent: exits 0 if the tag already points at this commit, fails if it points
+      # elsewhere so re-runs don't leave a mispointed tag.
       - name: Create Monorepo Release Tag via API
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          # Get the commit SHA of HEAD on master
           COMMIT_SHA=$(git rev-parse HEAD)
-          # Create lightweight tag via GitHub API (tags created via API are shown as verified)
-          gh api "repos/$REPOSITORY/git/refs" \
-            --method POST \
-            -f ref="refs/tags/v$RELEASE_VERSION" \
-            -f sha="$COMMIT_SHA"
+          encoded=$(printf '%s' "v${RELEASE_VERSION}" | jq -sRr @uri)
+          if existing_ref=$(gh api "repos/${REPOSITORY}/git/ref/tags/${encoded}" 2>/dev/null); then
+            existing_type=$(printf '%s' "$existing_ref" | jq -r '.object.type')
+            existing_obj=$(printf '%s' "$existing_ref" | jq -r '.object.sha')
+            if [ "$existing_type" = "tag" ]; then
+              existing_commit=$(gh api "repos/${REPOSITORY}/git/tags/${existing_obj}" --jq '.object.sha')
+            else
+              existing_commit="$existing_obj"
+            fi
+            if [ "$existing_commit" = "$COMMIT_SHA" ]; then
+              echo "Tag v${RELEASE_VERSION} already points at ${COMMIT_SHA}, nothing to do"
+              exit 0
+            fi
+            echo "::error::Tag v${RELEASE_VERSION} exists on origin but points at ${existing_commit} (expected ${COMMIT_SHA})"
+            exit 1
+          fi
+
+          tag_obj_sha=$(gh api --method POST "repos/${REPOSITORY}/git/tags" \
+            -f "tag=v${RELEASE_VERSION}" \
+            -f "message=chore(monorepo): release v${RELEASE_VERSION}" \
+            -f "object=${COMMIT_SHA}" \
+            -f "type=commit" \
+            --jq '.sha')
+
+          gh api --method POST "repos/${REPOSITORY}/git/refs" \
+            -f "ref=refs/tags/v${RELEASE_VERSION}" \
+            -f "sha=${tag_obj_sha}"
 
       - name: Get the two latest versions
         run: |
@@ -107,7 +131,9 @@ jobs:
         id: create_release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # App token aliased onto GITHUB_TOKEN (the var nx reads); the job's default
+          # token is contents:read and cannot create releases.
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           npm run release:github -- --base=$last_version --head=$current_version
 


### PR DESCRIPTION
## Description

The PAT → GitHub-App-token migration (**SEC-58**, #568, merged 18 Jun 2026) left the release pipeline unable to complete. Because the previous release (`v2.42.0`) shipped **before** that migration, this is the **first release cycle to run the new workflows** — and a `Draft new release` run ([28099549215](https://github.com/rudderlabs/rudder-sdk-react-native/actions/runs/28099549215)) failed at the version step with `fatal: empty ident name`.

A full audit (cross-validated against `rudderlabs/rudder-sdk-js`, which has the identical nx + `@jscutlery/semver` pipeline, went through the same SEC-58 migration, and has cut 7+ green releases since) surfaced **four** issues introduced by SEC-58. This PR fixes all four, mirroring the proven `rudder-sdk-js` configuration. No security property of SEC-58 is weakened — the changes restore an auth-agnostic git identity, fix a token/permission mismatch, and correct tag ownership.

### Root cause summary

| # | Issue | Effect |
|---|---|---|
| 1 | SEC-58 deleted the `Initialize mandatory git config` step from `draft` | `git merge` / semver have no commit author → `empty ident name`, draft fails |
| 2 | `draft` and `publish` both create the monorepo `v<version>` tag | `publish`'s tag API call collides (`422 ref exists`); tag also pointed at the pre-merge commit |
| 3 | `Create GitHub Releases` uses the default `secrets.GITHUB_TOKEN`, but the job runs with `contents: read` | GitHub Release creation would be refused (403) |
| 4 | `--skip.tag` + no replacement step means per-package `{projectName}@x.y.z` tags are never created | version computation (which counts commits since each package's last tag) drifts on the **next** release |

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

**`.github/workflows/draft-new-release.yml`**
- Re-add the `Initialize mandatory git config` step before `Create release branch` (which runs `git merge origin/master`) — fixes #1.
- Remove the `tag: 'v<version>'` input from the `Create verified commit via API` (signed-commit) step so draft no longer creates the monorepo tag — fixes #2. `publish` is now the sole creator of `v<version>`.
- Add a `Push release tags to release branch HEAD` step that creates annotated per-package tags (`rudder-sdk-react-native@x.y.z`, etc.) via the Git Data API at the release-branch HEAD — fixes #4. It iterates `libs/*/project.json` + `libs/plugins/*/project.json`, only tags packages whose `package.json` version changed vs `origin/master`, and is idempotent (skips if the tag already points at the release SHA, fails loudly if it points elsewhere).

**`.github/workflows/publish-new-release.yml`**
- Alias the App token (generated with `permission-contents: write`) onto the `GITHUB_TOKEN` env var that `nx`/`release:github` reads, since the job runs with `contents: read` — fixes #3.
- Make `Create Monorepo Release Tag via API` idempotent and switch it to an annotated tag object + ref, with loud-fail on a mispointed tag — safe re-runs after a partial failure.

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works. — N/A (CI workflow logic; validated against the proven `rudder-sdk-js` reference and YAML-parsed locally)
- [x] I have added the necessary documentation (if appropriate). — inline comments explain every non-obvious step
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary. — N/A
- [x] I have checked the code for security issues. — preserves SEC-58's intent: least-privilege `permissions` unchanged, App token still scoped, no PAT reintroduced; the re-added git identity is a static author string
- [x] I have updated the changelog (if required). — N/A (CI-only change, `ci` commit type is skipped by the release pipeline)

## How to test?

This cannot be fully exercised without running the release pipeline. Verification performed / recommended:
1. **Static:** both workflow files parse as valid YAML; the per-package loop correctly skips any `project.json` without a `targets.github.options.tag` (so only the 11 publishable packages get tagged; `example` is excluded).
2. **Reference parity:** every change mirrors `rudderlabs/rudder-sdk-js`'s `draft-new-release.yml` / `publish-new-release.yml`, which have produced 7+ successful releases post-SEC-58.
3. **End-to-end:** trigger `Draft new release` from `develop` after merge → expect a green run that creates `release/<ver>`, the per-package tags, and the PR into `master`; on merging that PR, `Publish new release` should create the monorepo tag, the GitHub Releases, and the back-merge PR.

> Note: a leftover `release/2.43.0` branch from the failed run should be deleted before re-triggering.

## Breaking Changes
None. CI-only; no SDK/runtime code is touched.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
- Failing run that triggered this investigation: https://github.com/rudderlabs/rudder-sdk-react-native/actions/runs/28099549215
- Origin of the regression: #568 (SEC-58).
- Reference implementation: `rudderlabs/rudder-sdk-js` (`draft-new-release.yml`, `publish-new-release.yml`), incl. follow-ups #2816 (remote-branch-via-API) and #2972 (per-package tags at release HEAD).
