### PR TITLE
fix(release): correct semver flags, signed commits & idempotent release steps

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -77,6 +77,7 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
+          git checkout -b "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
@@ -84,6 +85,8 @@ jobs:
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
 
+      # The signed-commit action requires the branch to exist on the remote.
+      # Idempotent: update the ref if it already exists (e.g. a re-run), create it otherwise.
       - name: Create release branch via API
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -91,10 +94,17 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           BASE_SHA=$(git rev-parse HEAD)
-          gh api "repos/$REPOSITORY/git/refs" \
-            --method POST \
-            -f ref="refs/heads/$BRANCH_NAME" \
-            -f sha="$BASE_SHA"
+          if gh api "repos/$REPOSITORY/git/ref/heads/$BRANCH_NAME" >/dev/null 2>&1; then
+            gh api "repos/$REPOSITORY/git/refs/heads/$BRANCH_NAME" \
+              --method PATCH \
+              -f sha="$BASE_SHA" \
+              -F force=true
+          else
+            gh api "repos/$REPOSITORY/git/refs" \
+              --method POST \
+              -f ref="refs/heads/$BRANCH_NAME" \
+              -f sha="$BASE_SHA"
+          fi
 
       - name: Update changelog & bump version
         id: finish-release
@@ -103,7 +113,7 @@ jobs:
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           git fetch --no-tags --prune --depth=100 origin master
-          npm run release -- --skip.commit --skip.tag
+          npm run release -- --skipCommit=true
           ./scripts/sync-tags-in-nx-projects.sh
           ./scripts/generate-last-release-changelog.sh
           ./scripts/update-rn-sdk-version-in-constants-file.sh
@@ -111,23 +121,18 @@ jobs:
           npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE sonar-project.properties
           npm i
 
-      - name: Get list of changed files
-        id: changed-files
-        run: |
-          # Get all changed files and format them for the signed commit action
-          changed_files=$(git diff --name-only | tr '\n' '\n')
-          echo "files<<EOF" >> $GITHUB_OUTPUT
-          echo "$changed_files" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
+      # semver runs with --skipCommit=true, so it stages the version/changelog changes
+      # without committing. This action packages all working-tree changes (files: .) into
+      # one verified commit on the release branch.
       - name: Create verified commit via API
-        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        uses: ryancyq/github-signed-commit@6afa32d8aa9819faddc248e6258e9c11ec05ecc8 # v1.4.0
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         with:
           branch-name: ${{ steps.create-release.outputs.branch_name }}
           commit-message: 'chore: sync versions and generate release logs'
-          files: ${{ steps.changed-files.outputs.files }}
+          files: |
+            .
 
       # Create per-package tags (rudder-sdk-react-native@x.y.z, etc.) at the release
       # branch HEAD for packages whose version changed. The monorepo v<version> tag is
@@ -196,12 +201,20 @@ jobs:
               -f "sha=${tag_obj_sha}"
           done
 
+      # Reviewers are auto-requested via CODEOWNERS (* @rudderlabs/sdk-rn).
+      # Idempotent: skip if a PR for this branch already exists (e.g. a re-run).
       - name: Create pull request into master
-        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
-        with:
-          source_branch: ${{ steps.create-release.outputs.branch_name }}
-          destination_branch: 'master'
-          github_token: ${{ steps.generate-token.outputs.token }}
-          pr_title: 'chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master'
-          pr_body: ':crown: *An automated PR*'
-          pr_reviewer: '@rudderlabs/sdk-rn'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BRANCH_NAME: ${{ steps.create-release.outputs.branch_name }}
+        run: |
+          existing=$(gh pr list --head "$BRANCH_NAME" --base master --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "PR #$existing from $BRANCH_NAME into master already exists; skipping"
+          else
+            gh pr create \
+              --base master \
+              --head "$BRANCH_NAME" \
+              --title "chore(release): pulling $BRANCH_NAME into master" \
+              --body ":crown: *An automated PR*"
+          fi

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -129,23 +129,36 @@ jobs:
 
       - name: Create GitHub Releases
         id: create_release
+        continue-on-error: true
         env:
           HUSKY: 0
           # App token aliased onto GITHUB_TOKEN (the var nx reads); the job's default
           # token is contents:read and cannot create releases.
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
+          # nx treats package.json / package-lock.json changes as affecting every package.
+          # Ignore them so only genuinely-changed packages get a GitHub release.
+          # Ref: https://github.com/nrwl/nx/issues/15116#issuecomment-1535260119
+          echo package-lock.json >> .nxignore
+          echo package.json >> .nxignore
           npm run release:github -- --base=$last_version --head=$current_version
+          # Restore working copy
+          git checkout -- .nxignore
 
+      # Reviewers are auto-requested via CODEOWNERS (* @rudderlabs/sdk-rn).
+      # continue-on-error: a back-merge hiccup (e.g. PR already open) must not fail the
+      # release after the GitHub releases are already published.
       - name: Create pull request into develop
-        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
-        with:
-          source_branch: 'master'
-          destination_branch: 'develop'
-          github_token: ${{ steps.generate-token.outputs.token }}
-          pr_title: 'chore(release): pulling master into develop post release v${{ steps.extract-version.outputs.release_version }}'
-          pr_body: ':crown: *An automated PR*'
-          pr_reviewer: '@rudderlabs/sdk-rn'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
+        run: |
+          gh pr create \
+            --base develop \
+            --head master \
+            --title "chore(release): pulling master into develop post release v$RELEASE_VERSION" \
+            --body ":crown: *An automated PR*"
 
       - name: Delete hotfix release branch
         uses: koj-co/delete-merged-action@63a03c35810a8a7d4840d18793c0f68ff8b59450 # master


### PR DESCRIPTION
## Description

Follow-up to #636. With #636 merged, the first real **Draft new release** run ([28159657426](https://github.com/rudderlabs/rudder-sdk-react-native/actions/runs/28159657426)) cleared the version/changelog step (the original SEC-58 failure) but then failed at **Create verified commit via API**.

Root cause: the draft workflow ran `npm run release -- --skip.commit --skip.tag`, but `@jscutlery/semver` has **no `skip.commit`/`skip.tag` options** — the only valid option is `--skipCommit` (verified against the installed `@jscutlery/semver@5.7.1` schema). The dotted flags were silently ignored, so semver created its **own per-project commits** (e.g. `chore(example): release version 3.7.1`), corrupting the branch state the signed-commit action then expected (`Expected branch to point to <sha> … Pull and try again`). This was masked earlier by the git-identity failure that #636 fixed.

This PR aligns the draft and publish workflows with the proven `rudderlabs/rudder-sdk-js` pipeline (same nx + `@jscutlery/semver` setup, same SEC-58 migration, 7+ green releases since), including the PR-creation/back-merge steps that SEC-58 swapped from PAT to the App token but which have never run since.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

**`.github/workflows/draft-new-release.yml`**
- **Fix the skip flag (root cause):** `--skip.commit --skip.tag` → `--skipCommit=true`. semver now writes/stages version + changelog files without making its own commits.
- **Capture the staged changes:** bump `ryancyq/github-signed-commit` to `v1.4.0` and pass `files: .` (all working-tree changes). The old `git diff --name-only` list only captured *unstaged* files and would miss semver's staged bumps. Removed the now-redundant "Get list of changed files" step.
- **Self-healing branch setup:** create the local release branch (`git checkout -b`) and make the remote-branch API call idempotent (`PATCH … force=true` if the ref exists, else `POST`). Re-runs no longer require deleting the leftover `release/<ver>` branch.
- **PR creation:** replace `repo-sync/pull-request` with `gh pr create` (idempotent — skips if a PR for the branch already exists). Reviewers come from CODEOWNERS (`* @rudderlabs/sdk-rn`).

**`.github/workflows/publish-new-release.yml`**
- **Create GitHub Releases:** add the `.nxignore` trick (ignore `package.json` / `package-lock.json`, which nx otherwise treats as affecting every package) and `continue-on-error: true`. The release-creation design (confirmed against a real `rudder-sdk-js` run) creates a release per affected package; unchanged packages fail with "already exists" and are absorbed by `continue-on-error`.
- **Back-merge PR:** replace `repo-sync/pull-request` (master → develop) with `gh pr create` + `continue-on-error`. Reviewers come from CODEOWNERS.

## Scope note (no business-logic change)
- **Unchanged:** how versions are computed, which packages are version-bumped, what is published to npm, changelog content.
- **Mechanism-only (same outcome):** skip flag, `files: .`, `git checkout -b`, `gh pr create` (replacing `repo-sync/pull-request`).
- **Intentional behavior changes (Publish, copied from rudder-sdk-js):** release pages scoped to changed packages only; release-page + back-merge failures tolerated.

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works. — N/A (CI workflow logic). Validated via: `@jscutlery/semver@5.7.1` schema + source; a real successful `rudder-sdk-js` publish run (confirming the release:github + continue-on-error design); `actionlint`/`shellcheck` (no structural errors, no new findings); a local dry-run of the per-package tag loop.
- [x] I have added the necessary documentation (if appropriate). — inline comments on each non-obvious step.
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary. — N/A
- [x] I have checked the code for security issues. — preserves SEC-58: least-privilege `permissions` unchanged, App token still scoped, no PAT reintroduced.
- [x] I have updated the changelog (if required). — N/A (CI-only; `ci` commit type is skipped by the release pipeline).

## How to test?
Cannot be fully exercised without running the pipeline. Verification performed:
1. **Static:** both workflows parse as valid YAML; `actionlint`/`shellcheck` report no structural errors and no new findings in the changed steps.
2. **Source-level:** confirmed `@jscutlery/semver@5.7.1` `skipCommit` stages-but-doesn't-commit (hence `files: .`).
3. **Ground truth:** inspected a successful `rudder-sdk-js` publish run — `release:github` runs per affected package, unchanged packages fail "already exists" and are absorbed by `continue-on-error`; RN now matches.
4. **Logic dry-run:** per-package tag loop selects exactly the changed packages (sdk, sprig, db-encryption).
5. **End-to-end:** after merge, trigger **Draft new release** from `develop` → expect green through to the release PR; merging that PR exercises Publish.

## Breaking Changes
None. CI-only; no SDK/runtime code touched.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
- Failing run that triggered this fix: https://github.com/rudderlabs/rudder-sdk-react-native/actions/runs/28159657426
- Predecessor: #636 (git identity, tag ownership, token/permission). This PR fixes the remaining semver-flag + signed-commit issues it exposed, and aligns the PR-creation/back-merge steps (also SEC-58-touched, never run since).
- Reference implementation: `rudderlabs/rudder-sdk-js` (`draft-new-release.yml`, `publish-new-release.yml`).
