### PR TITLE
feat(braze): raise native braze integration minimum versions

### DIFF
--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -14,7 +14,7 @@ PODS:
     - AppsFlyerFramework/Main (= 6.18.0)
   - AppsFlyerFramework/Main (6.18.0)
   - boost (1.84.0)
-  - BrazeKit (14.1.0)
+  - BrazeKit (14.2.1)
   - CleverTap-iOS-SDK (4.2.2):
     - SDWebImage (~> 5.11)
   - DoubleConversion (1.1.6)
@@ -2696,7 +2696,7 @@ PODS:
   - Rudder-Appsflyer (3.1.0):
     - AppsFlyerFramework (~> 6.14)
     - Rudder (~> 1.12)
-  - Rudder-Braze (4.4.0):
+  - Rudder-Braze (4.5.0):
     - BrazeKit (< 15.0.0, >= 14.0.1)
     - Rudder (~> 1.26)
   - Rudder-CleverTap (1.1.2):
@@ -2723,7 +2723,7 @@ PODS:
   - rudder-integration-braze-react-native (2.4.0):
     - React
     - RNRudderSdk
-    - Rudder-Braze (~> 4.4)
+    - Rudder-Braze (~> 4.5)
   - rudder-integration-clevertap-react-native (1.3.0):
     - CleverTap-iOS-SDK
     - React
@@ -3164,7 +3164,7 @@ SPEC CHECKSUMS:
   AppCenter: 38e27eb52113bff74426db9f500726933c8d2fd7
   AppsFlyerFramework: c1e1e4cd3b98ffdca2fe32b17ae93909e409b6ab
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  BrazeKit: ef0a5193484c1a49f06c2520cedce7b2c3e1d9e4
+  BrazeKit: 0be39d61821a82edc34625c7f53cf358065deee6
   CleverTap-iOS-SDK: 36c21b8a671d87a0f9c7b389b339d02528bbe4d7
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
@@ -3261,7 +3261,7 @@ SPEC CHECKSUMS:
   Rudder-Amplitude: d308b2bce1237c3cfdf3274458130f36815067db
   Rudder-AppCenter: 9eca9241e3707a0e9610714dd91dc8da4bae7e1f
   Rudder-Appsflyer: dcefa779746771d8af96a2b70c45b3f4a1cc18e5
-  Rudder-Braze: 2371de6a4fbee74df5a2e9656995675a667062b9
+  Rudder-Braze: 7472471785e2821b83be81adec1a79a7edabac19
   Rudder-CleverTap: a0085aab472e0e60930c4301ef80bae5ff187e98
   Rudder-Facebook: 24c9309373f13212d1139938aad86faa2914d342
   Rudder-Firebase: 876e5c2271915513315ce91c497ae5335b787950

--- a/libs/rudder-integration-braze-react-native/android/build.gradle
+++ b/libs/rudder-integration-braze-react-native/android/build.gradle
@@ -42,5 +42,5 @@ dependencies {
     // rudderstack dependencies
     implementation project(path: ':rudderstack_rudder-sdk-react-native')  // From node_modules
     implementation 'com.rudderstack.android.sdk:core:[1.27.1, 2.0.0)'
-    implementation 'com.rudderstack.android.integration:braze:[2.2.0,3.0.0)'
+    implementation 'com.rudderstack.android.integration:braze:[2.3.0,3.0.0)'
 }

--- a/libs/rudder-integration-braze-react-native/rudder-integration-braze-react-native.podspec
+++ b/libs/rudder-integration-braze-react-native/rudder-integration-braze-react-native.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.static_framework = true 
 
   s.dependency "React"
-  s.dependency "Rudder-Braze", '~> 4.4'
+  s.dependency "Rudder-Braze", '~> 4.5'
   s.dependency 'RNRudderSdk'
 
 end


### PR DESCRIPTION
## Description
Raises the minimum supported versions of the native RudderStack Braze integrations that the React Native Braze integration (`@rudderstack/rudder-integration-braze-react-native`) depends on, to align with the latest native releases:

- **Android** `com.rudderstack.android.integration:braze`: floor raised from `2.2.0` to `2.3.0` (range `[2.3.0,3.0.0)`).
- **iOS** `Rudder-Braze`: floor raised from `~> 4.4` to `~> 4.5`.

Both native dependencies are declared as version ranges, so a clean build already resolved to the latest in-range native SDK (Android `2.3.0`, iOS `4.5.0`). This change lifts the validated floor so the integration cannot resolve below the versions we have verified, and documents the supported pairing — consistent with prior min-version bump releases (e.g. #596, #562, #525).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- `libs/rudder-integration-braze-react-native/android/build.gradle`: updated the Braze integration dependency range from `[2.2.0,3.0.0)` to `[2.3.0,3.0.0)`.
- `libs/rudder-integration-braze-react-native/rudder-integration-braze-react-native.podspec`: updated the `Rudder-Braze` dependency constraint from `~> 4.4` to `~> 4.5`.
- No source, API, or behavioral changes — dependency-declaration-only change.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Install/link the updated `@rudderstack/rudder-integration-braze-react-native` in an app that has the Braze device-mode integration enabled.
2. **Android**: run a clean build with refreshed dependencies and confirm resolution:
   ```bash
   cd android && ./gradlew :app:dependencies --configuration releaseRuntimeClasspath --refresh-dependencies | grep -i braze
   # expect: com.rudderstack.android.integration:braze:[2.3.0,3.0.0) -> 2.3.0
   ```
3. **iOS**: refresh pods and confirm the resolved version:
   ```bash
   cd ios && pod repo update && pod update Rudder-Braze
   grep -i braze Podfile.lock   # expect: Rudder-Braze (4.5.0)
   ```
4. Verify Braze device-mode events (identify/track/screen) still flow through end-to-end.

## Breaking Changes
None. Both dependencies were already declared as ranges that resolved to the new floor; the minimums are simply raised.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
Linear: SDK-5081. Follows the established pattern of shipping a corresponding RN integration release whenever the native Android/iOS Braze integrations release a new version. Latest native releases at time of change: Android `2.3.0` (2026-07-06) and iOS `4.5.0` (2026-07-01).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Braze integration dependency requirements for both Android and iOS.
  * The library now resolves to newer compatible Braze versions, improving alignment with current releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->