### PR TITLE
ci(deploy): keep partial releases green and verify published versions

### DIFF
--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -57,12 +57,36 @@ jobs:
           echo "last_version=$(echo $LAST_VERSION)" >> "$GITHUB_OUTPUT"
           echo "DATE=$(date)" >> "$GITHUB_OUTPUT"
 
+      # continue-on-error: on a partial release, changelog regeneration marks
+      # unchanged packages as nx-affected; their `npm publish` is rejected with
+      # "cannot publish over previously published version". Those rejections are
+      # expected — the verify step below catches genuine publish failures.
       - name: Build & Publish affected packages
+        continue-on-error: true
         env:
           current_version: ${{ steps.get-versions.outputs.current_version }}
           last_version: ${{ steps.get-versions.outputs.last_version }}
         run: |
           npm run deploy:npm -- --base=$last_version --head=$current_version
+
+      # Every package with a deploy target must have its package.json version live
+      # on npm: unchanged packages resolve to their old (published) version, bumped
+      # packages to the new one — so a genuine publish failure fails the job here.
+      - name: Verify published versions on npm
+        run: |
+          FAILED=0
+          for proj in $(grep -rl '"deploy"' --include=project.json libs); do
+            pkg="$(dirname "$proj")/package.json"
+            NAME=$(node -p "require('./$pkg').name")
+            VERSION=$(node -p "require('./$pkg').version")
+            if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+              echo "✅ $NAME@$VERSION is live on npm"
+            else
+              echo "❌ $NAME@$VERSION is NOT on npm"
+              FAILED=1
+            fi
+          done
+          exit $FAILED
 
       - name: Send message to Slack channel
         id: slack


### PR DESCRIPTION
## Summary

Fixes SDK-5048. On a partial release (only some monorepo packages bumped), the `Deploy to NPM` job goes red even though the release is correct: release-time changelog regeneration rewrites `CHANGELOG_LATEST.md` for every package, `nx affected` therefore hands *all* packages to the deploy target, and npm rejects the unchanged ones with `You cannot publish over the previously published versions`. Those expected rejections failed the whole job (seen on v2.43.0, run 28354137269, where 3 packages were bumped and published fine but the other 9 turned the job red).

This PR makes the publish step tolerant of the expected rejections and adds an explicit post-publish verification so a genuine publish failure still fails the job.

## Changes

- `.github/workflows/deploy-npm.yml`
  - Added `continue-on-error: true` to the `Build & Publish affected packages` step (with a comment explaining why the rejections are expected), mirroring how `publish-new-release.yml` handles the equivalent "already exists" case.
  - Added a `Verify published versions on npm` step between publish and the Slack notification. It iterates every package with a `deploy` target (derived from `project.json` files, so nested packages like `libs/plugins/rudder-plugin-db-encryption-react-native` are included) and checks `npm view <name>@<version>`. Unchanged packages resolve to their old (already published) version and pass; a bumped package whose publish genuinely failed is missing from the registry and fails the job. The loop checks all packages before exiting so the log always shows the complete picture.
  - The verify step runs before the Slack release announcement, so a failed release is never announced.

## Testing

- Ran the verify script locally against the live registry: all 12 packages report `✅ ... is live on npm`, exit 0.
- Full in-CI replay of the v2.43.0 failure scenario — dispatched this workflow from this branch (temporarily enabling branch dispatch and muting Slack via commits that have since been dropped): all 12 publishes were rejected with "cannot publish over the previously published versions" and the job finished **green**, verify step 12/12 ✅ — run 29095932446.
- Negative test — simulated a missing published version (`@rudderstack/rudder-sdk-react-native@99.99.99`): verify step reported `❌ ... is NOT on npm` and the job finished **red** — run 29096182049.
- `actionlint` on the workflow: no errors (remaining shellcheck notes are pre-existing style hints).

## Screenshots

No UI changes in this PR.

## Notes

- No breaking changes or migration steps required. This workflow triggers via `workflow_run`, which executes the definition from the default branch — the fix is active immediately after merging to `develop`; no release is needed to arm it.
- Final acceptance check happens naturally with the next partial release, which should now go green.
- Out of scope, tracked as follow-ups in SDK-5048: pinning the changelog preset to a valid value (root cause of the mass changelog rewrites) and migrating to `nx release publish` (idempotent, as used in rudder-sdk-js).

Tip: the run IDs become clickable if you wrap them as links — [29095932446](https://github.com/rudderlabs/rudder-sdk-react-native/actions/runs/29095932446) and [29096182049](https://github.com/rudderlabs/rudder-sdk-react-native/actions/runs/29096182049).