### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: "@rudderlabs/sdk-rn"
+assignees: "@rudderlabs/sdk_team"
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: 'Feature Request: <Title>'
 labels: open source
-assignees: "@rudderlabs/sdk-rn"
+assignees: "@rudderlabs/sdk_team"
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -201,7 +201,7 @@ jobs:
               -f "sha=${tag_obj_sha}"
           done
 
-      # Reviewers are auto-requested via CODEOWNERS (* @rudderlabs/sdk-rn).
+      # Reviewers are auto-requested via CODEOWNERS.
       # Idempotent: skip if a PR for this branch already exists (e.g. a re-run).
       - name: Create pull request into master
         env:

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -145,7 +145,7 @@ jobs:
           # Restore working copy
           git checkout -- .nxignore
 
-      # Reviewers are auto-requested via CODEOWNERS (* @rudderlabs/sdk-rn).
+      # Reviewers are auto-requested via CODEOWNERS.
       # continue-on-error: a back-merge hiccup (e.g. PR already open) must not fail the
       # release after the GitHub releases are already published.
       - name: Create pull request into develop

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rudderlabs/sdk-rn
+* @rudderlabs/sdk_team


### PR DESCRIPTION
## Summary

Replaces the repo's code owners with the whole SDK team (`@rudderlabs/sdk_team`) so any team member's review can unblock chore PRs (Dependabot merges, CI fixes) instead of waiting on the `sdk-rn` sub-team. Feat/fix PRs can continue to involve the relevant reviewers via explicit review requests. Part of the SDK-5102 rollout across SDK repos; resolves SDK-5106.

## Changes

- `CODEOWNERS` (repo root): default owner changed from `@rudderlabs/sdk-rn` to `@rudderlabs/sdk_team`; also adds the missing trailing newline.

## Testing

- Verified `@rudderlabs/sdk_team` already has write access on this repo, so GitHub honors it as code owner as soon as this merges — no access changes needed.
- Post-merge check: the next PR should auto-request review from `sdk_team`, and any member's approval should satisfy the code-owner requirement.

## Screenshots

No UI changes in this PR.

## Notes

No breaking changes or migration steps required. Review-routing change only — no workflow or build behavior is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership settings for the SDK codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->