### PR TITLE
chore: sdk-5239 target dependabot updates to master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,13 @@ updates:
     directory: "/" 
     schedule:
       interval: "weekly"
-    target-branch: "develop"
+    target-branch: "master"
 
   - package-ecosystem: "npm"
     directory: "/" 
     schedule:
       interval: "weekly"
-    target-branch: "develop"
+    target-branch: "master"
     groups:
       npm-prod-deps:
         patterns:


### PR DESCRIPTION
## Summary

- target GitHub Actions dependency updates at `master`
- target npm dependency updates at `master`

## Why

`master` is now the repository's default and single development branch. Keeping Dependabot on `develop` would continue creating dependency PRs against the branch being retired.

## Impact

Future Dependabot updates will target `master`. This change does not modify or close existing Dependabot PRs.

## Validation

- parsed `.github/dependabot.yml` with Ruby's YAML parser
- asserted both configured `target-branch` values equal `master`
- confirmed no `develop` target remains
- ran `git diff --check`

## Release impact

None. This is repository maintenance only.

Linear: https://linear.app/rudderstack/issue/SDK-5239/point-react-native-sdk-dependabot-updates-to-master