### PR TITLE
feat: sdk-5301 expose android deep link tracking config

### DIFF
--- a/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNParamsConfigurator.java
+++ b/libs/sdk/android/src/main/java/com/rudderstack/react/android/RNParamsConfigurator.java
@@ -80,7 +80,10 @@ class RNParamsConfigurator {
         if (config.hasKey("collectDeviceId")) {
             configBuilder.withCollectDeviceId(config.getBoolean("collectDeviceId"));
         }
-        if(config.hasKey("enableGzip")) {
+        if (config.hasKey("trackDeepLinks")) {
+            configBuilder.withTrackDeepLinks(config.getBoolean("trackDeepLinks"));
+        }
+        if (config.hasKey("enableGzip")) {
             configBuilder.withGzip(config.getBoolean("enableGzip"));
         }
         return configBuilder;

--- a/libs/sdk/android/src/test/java/com/rudderstack/react/android/RNParamsConfiguratorTest.kt
+++ b/libs/sdk/android/src/test/java/com/rudderstack/react/android/RNParamsConfiguratorTest.kt
@@ -1,0 +1,45 @@
+package com.rudderstack.react.android
+
+import com.facebook.react.bridge.ReadableMap
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RNParamsConfiguratorTest {
+
+    @Test
+    fun `given trackDeepLinks is false, when config is built, then deep link tracking is disabled`() {
+        val config = configWith(trackDeepLinks = false)
+
+        val rudderConfig = RNParamsConfigurator(config).handleConfig().build()
+
+        assertFalse(rudderConfig.isTrackDeepLinks)
+    }
+
+    @Test
+    fun `given trackDeepLinks is omitted, when config is built, then deep link tracking remains enabled`() {
+        val config = configWith()
+
+        val rudderConfig = RNParamsConfigurator(config).handleConfig().build()
+
+        assertTrue(rudderConfig.isTrackDeepLinks)
+    }
+
+    private fun configWith(trackDeepLinks: Boolean? = null): ReadableMap {
+        val config = mockk<ReadableMap>()
+        every { config.hasKey(any()) } answers {
+            when (firstArg<String>()) {
+                "writeKey" -> true
+                "trackDeepLinks" -> trackDeepLinks != null
+                else -> false
+            }
+        }
+        every { config.getString("writeKey") } returns "write-key"
+        if (trackDeepLinks != null) {
+            every { config.getBoolean("trackDeepLinks") } returns trackDeepLinks
+        }
+        return config
+    }
+}

--- a/libs/sdk/src/Constants.ts
+++ b/libs/sdk/src/Constants.ts
@@ -15,4 +15,5 @@ export const AUTO_SESSION_TRACKING = true;
 export const SESSION_TIMEOUT = 300000;
 export const ENABLE_BACKGROUND_MODE = false;
 export const COLLECT_DEVICE_ID = true;
+export const TRACK_DEEP_LINKS = true;
 export const ENABLE_GZIP = true;

--- a/libs/sdk/src/NativeRudderBridge.ts
+++ b/libs/sdk/src/NativeRudderBridge.ts
@@ -19,6 +19,7 @@ export interface Configuration {
   sessionTimeout?: number;
   enableBackgroundMode?: boolean;
   collectDeviceId?: boolean;
+  trackDeepLinks?: boolean;
   enableGzip?: boolean;
   dbEncryption?: unknown;
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/libs/sdk/src/RudderClient.spec.ts
+++ b/libs/sdk/src/RudderClient.spec.ts
@@ -1,0 +1,71 @@
+import rudderClient from './RudderClient';
+import bridge from './NativeRudderBridge';
+import { DATA_PLANE_URL } from './Constants';
+import { RUDDER_LOG_LEVEL } from './Logger';
+
+jest.mock('./NativeRudderBridge', () => ({
+  __esModule: true,
+  default: {
+    setup: jest.fn().mockResolvedValue(undefined),
+    track: jest.fn(),
+    screen: jest.fn(),
+    identify: jest.fn(),
+    alias: jest.fn(),
+    group: jest.fn(),
+    reset: jest.fn(),
+    flush: jest.fn(),
+    optOut: jest.fn(),
+    putDeviceToken: jest.fn(),
+    putAdvertisingId: jest.fn(),
+    clearAdvertisingId: jest.fn(),
+    putAnonymousId: jest.fn(),
+    registerCallback: jest.fn(),
+    getRudderContext: jest.fn(),
+    startSession: jest.fn(),
+    endSession: jest.fn(),
+    getSessionId: jest.fn(),
+  },
+}));
+
+const mockedBridge = bridge as jest.Mocked<typeof bridge>;
+
+describe('rudderClient setup configuration validation', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('preserves explicit false for trackDeepLinks', async () => {
+    await rudderClient.setup('write-key', {
+      dataPlaneUrl: DATA_PLANE_URL,
+      trackDeepLinks: false,
+    });
+
+    expect(mockedBridge.setup).toHaveBeenCalledWith(
+      expect.objectContaining({ trackDeepLinks: false }),
+      null,
+    );
+  });
+
+  it('removes invalid trackDeepLinks values before configuration defaults are applied', async () => {
+    await rudderClient.setup('write-key', {
+      dataPlaneUrl: DATA_PLANE_URL,
+      logLevel: RUDDER_LOG_LEVEL.WARN,
+      trackDeepLinks: 'false' as unknown as boolean,
+    });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "RudderSDK: Warn: setup : 'trackDeepLinks' must be a boolean. Falling back to the default value true",
+    );
+    expect(mockedBridge.setup).toHaveBeenCalledWith(
+      expect.objectContaining({ trackDeepLinks: true }),
+      null,
+    );
+  });
+});

--- a/libs/sdk/src/RudderClient.ts
+++ b/libs/sdk/src/RudderClient.ts
@@ -4,7 +4,7 @@ import AsyncLock from 'async-lock';
 import { configure } from './RudderConfiguration';
 import bridge, { Configuration } from './NativeRudderBridge';
 import { logInit, logDebug, logError, logWarn } from './Logger';
-import { SDK_VERSION, ENABLE_GZIP } from './Constants';
+import { SDK_VERSION, ENABLE_GZIP, TRACK_DEEP_LINKS } from './Constants';
 import IRudderContext from './IRudderContext';
 import { filterNaN } from './FilterNaN';
 
@@ -77,6 +77,15 @@ function validateConfiguration(configuration: Configuration) {
   if (configuration.collectDeviceId && typeof configuration.collectDeviceId != 'boolean') {
     logWarn("setup : 'collectDeviceId' must be a boolean. Falling back to the default value");
     delete configuration.collectDeviceId;
+  }
+  if (
+    configuration.trackDeepLinks !== undefined &&
+    typeof configuration.trackDeepLinks !== 'boolean'
+  ) {
+    logWarn(
+      `setup : 'trackDeepLinks' must be a boolean. Falling back to the default value ${TRACK_DEEP_LINKS}`,
+    );
+    delete configuration.trackDeepLinks;
   }
   if (
     typeof configuration.enableGzip !== 'undefined' &&

--- a/libs/sdk/src/RudderConfiguration.ts
+++ b/libs/sdk/src/RudderConfiguration.ts
@@ -14,6 +14,7 @@ import {
   SESSION_TIMEOUT,
   ENABLE_BACKGROUND_MODE,
   COLLECT_DEVICE_ID,
+  TRACK_DEEP_LINKS,
   ENABLE_GZIP,
 } from './Constants';
 
@@ -36,6 +37,7 @@ export const configure = async (
     trackAppLifecycleEvents = TRACK_LIFECYCLE_EVENTS,
     recordScreenViews = RECORD_SCREEN_VIEWS,
     collectDeviceId = COLLECT_DEVICE_ID,
+    trackDeepLinks = TRACK_DEEP_LINKS,
     enableGzip = ENABLE_GZIP,
     dbEncryption,
     withFactories = [],
@@ -75,6 +77,7 @@ export const configure = async (
     enableBackgroundMode,
     recordScreenViews,
     collectDeviceId,
+    trackDeepLinks,
     enableGzip,
   };
 


### PR DESCRIPTION
## Summary

- expose `trackDeepLinks?: boolean` in the React Native SDK configuration
- keep the default value `true`
- pass the value to Android through `RudderConfig.Builder.withTrackDeepLinks`
- validate invalid JavaScript values and preserve explicit `false`
- add focused JavaScript and Android native tests

## Scope

This PR contains only the SDK-5301 implementation and tests. It replaces #684.

## Validation

- `npx nx run-many --target=lint --skip-nx-cache`
- `npx nx run-many --target=type-check --skip-nx-cache`
- `npx nx run-many --target=test --skip-nx-cache`
- `npx nx run-many --target=build --exclude=example --skip-nx-cache`
- `npx nx bundle-ios example`
- `npx nx bundle-android example`
- `./apps/example/android/gradlew -p apps/example/android :rudderstack_rudder-sdk-react-native:testDebugUnitTest`
- `npx nx build-android example`
- `npx nx build-ios-ci example` on the equivalent focused implementation

## Known baseline check

`npm run check:security` reports existing high-severity findings from the unchanged `master` dependency graph. This PR does not change dependencies or security policy.

Linear: https://linear.app/rudderstack/issue/SDK-5301/react-native-sdk-expose-trackdeeplinks-config-flag-to-control-android


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to enable or disable deep-link tracking.
  * Deep-link tracking is enabled by default.
  * The setting is supported across JavaScript and Android configuration.

* **Bug Fixes**
  * Invalid deep-link tracking values now trigger a warning and safely fall back to the default enabled behavior.

* **Tests**
  * Added coverage for disabled, omitted, and invalid deep-link tracking settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->