### PR TITLE
chore: add new branding images to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<p align="center">
+  <a href="https://rudderstack.com/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-dark.png">
+      <img alt="RudderStack" width="512" src="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-light.jpg">
+    </picture>
+  </a>
+</p>
+
 # What is RudderStack?
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-sdk-react-native)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://rudderstack.com/">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-dark.png">
-      <img alt="RudderStack" width="512" src="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-light.jpg">
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.rudderlabs.com/brand/logo_watermark_dark.png">
+      <img alt="RudderStack" width="512" src="https://cdn.rudderlabs.com/brand/logo_watermark_light.png">
     </picture>
   </a>
 </p>

--- a/libs/sdk/README.md
+++ b/libs/sdk/README.md
@@ -1,3 +1,12 @@
+<p align="center">
+  <a href="https://rudderstack.com/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-dark.png">
+      <img alt="RudderStack" width="512" src="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-light.jpg">
+    </picture>
+  </a>
+</p>
+
 # What is RudderStack?
 
 [RudderStack](https://rudderstack.com/) is a **customer data pipeline** tool for collecting, routing and processing data from your websites, apps, cloud tools, and data warehouse.

--- a/libs/sdk/README.md
+++ b/libs/sdk/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://rudderstack.com/">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-dark.png">
-      <img alt="RudderStack" width="512" src="https://raw.githubusercontent.com/rudderlabs/rudder-sdk-js/develop/assets/rs-logo-full-light.jpg">
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.rudderlabs.com/brand/logo_watermark_dark.png">
+      <img alt="RudderStack" width="512" src="https://cdn.rudderlabs.com/brand/logo_watermark_light.png">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
## Summary

Adds the RudderStack branding header to the root README and the core package README (`libs/sdk`), which previously had no logo. Uses the standard theme-aware `<picture>` block (dark variant in dark mode, light as default/fallback) pointing at the canonical assets in the rudder-sdk-js repo — same pattern as the rest of the SDK repos. npm renders the light `<img>` fallback.

Docs-only change.

## Linear task

https://linear.app/rudderstack/issue/SDK-5116/update-sdk-repositories-and-packaged-assets-with-new-branding-images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a centered RudderStack logo banner to the main README.
  * Updated the SDK README with the same logo banner.
  * Logo links to the RudderStack website and adapts to light and dark display modes.
  * Updated logo assets to use RudderStack’s CDN for more stable image availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->