### PR TITLE
fix(build): restore packaged assets in libs after nx 22 migration

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,8 +1,8 @@
 .eslintrc.json
 babel.config.json
-CHANGELOG.md
+/CHANGELOG.md
 jest.config.ts
-README.md
+/README.md
 test-setup.ts
 tsconfig.json
 tsconfig.lib.json

--- a/libs/plugins/rudder-plugin-db-encryption-react-native/package.json
+++ b/libs/plugins/rudder-plugin-db-encryption-react-native/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/rudderlabs/rudder-sdk-react-native#readme",
   "peerDependencies": {
+    "@rudderstack/rudder-sdk-react-native": ">=1.11.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-native": ">= 0.41.2 < 0.90.0 || ^0.0.0-0"
   }

--- a/libs/plugins/rudder-plugin-db-encryption-react-native/project.json
+++ b/libs/plugins/rudder-plugin-db-encryption-react-native/project.json
@@ -16,30 +16,31 @@
         "external": ["react/jsx-runtime", "react-native"],
         "rollupConfig": "@nx/react/plugins/bundle-rollup",
         "babelUpwardRootMode": true,
+        "useLegacyTypescriptPlugin": true,
         "assets": [
           {
-            "glob": "libs/plugins/rudder-plugin-db-encryption-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/plugins/rudder-plugin-db-encryption-react-native",
             "output": "."
           },
           {
-            "glob": "libs/plugins/rudder-plugin-db-encryption-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/plugins/rudder-plugin-db-encryption-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/plugins/rudder-plugin-db-encryption-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-plugin-db-encryption-react-native.podspec",
+            "input": "libs/plugins/rudder-plugin-db-encryption-react-native",
             "output": "."
           },
           {
-            "glob": "libs/plugins/rudder-plugin-db-encryption-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/plugins/rudder-plugin-db-encryption-react-native/rudder-plugin-db-encryption-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/plugins/rudder-plugin-db-encryption-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/plugins/rudder-plugin-db-encryption-react-native",
             "output": "."
           },
           {

--- a/libs/plugins/rudder-plugin-db-encryption-react-native/project.json
+++ b/libs/plugins/rudder-plugin-db-encryption-react-native/project.json
@@ -47,6 +47,11 @@
             "glob": "LICENSE.md",
             "input": ".",
             "output": "."
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/plugins/rudder-plugin-db-encryption-react-native/src",
+            "output": "src"
           }
         ],
         "updateBuildableProjectDepsInPackageJson": true,

--- a/libs/rudder-integration-amplitude-react-native/project.json
+++ b/libs/rudder-integration-amplitude-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-amplitude-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-amplitude-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-amplitude-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-amplitude-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-amplitude-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-amplitude-react-native.podspec",
+            "input": "libs/rudder-integration-amplitude-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-amplitude-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-amplitude-react-native/rudder-integration-amplitude-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-amplitude-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-amplitude-react-native",
             "output": "."
           },
           {

--- a/libs/rudder-integration-appcenter-react-native/project.json
+++ b/libs/rudder-integration-appcenter-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-appcenter-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-appcenter-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-appcenter-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-appcenter-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-appcenter-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-appcenter-react-native.podspec",
+            "input": "libs/rudder-integration-appcenter-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-appcenter-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-appcenter-react-native/rudder-integration-appcenter-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-appcenter-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-appcenter-react-native",
             "output": "."
           },
           {

--- a/libs/rudder-integration-appsflyer-react-native/project.json
+++ b/libs/rudder-integration-appsflyer-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-appsflyer-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-appsflyer-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-appsflyer-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-appsflyer-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-appsflyer-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-appsflyer-react-native.podspec",
+            "input": "libs/rudder-integration-appsflyer-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-appsflyer-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-appsflyer-react-native/rudder-integration-appsflyer-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-appsflyer-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-appsflyer-react-native",
             "output": "."
           },
           {

--- a/libs/rudder-integration-braze-react-native/project.json
+++ b/libs/rudder-integration-braze-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-braze-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-braze-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-braze-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-braze-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-braze-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-braze-react-native.podspec",
+            "input": "libs/rudder-integration-braze-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-braze-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-braze-react-native/rudder-integration-braze-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-braze-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-braze-react-native",
             "output": "."
           },
           {

--- a/libs/rudder-integration-clevertap-react-native/project.json
+++ b/libs/rudder-integration-clevertap-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-clevertap-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-clevertap-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-clevertap-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-clevertap-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-clevertap-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-clevertap-react-native.podspec",
+            "input": "libs/rudder-integration-clevertap-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-clevertap-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-clevertap-react-native/rudder-integration-clevertap-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-clevertap-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-clevertap-react-native",
             "output": "."
           },
           {

--- a/libs/rudder-integration-facebook-react-native/project.json
+++ b/libs/rudder-integration-facebook-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-facebook-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-facebook-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-facebook-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-facebook-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-facebook-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-facebook-react-native.podspec",
+            "input": "libs/rudder-integration-facebook-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-facebook-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-facebook-react-native/rudder-integration-facebook-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-facebook-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-facebook-react-native",
             "output": "."
           },
           {

--- a/libs/rudder-integration-firebase-react-native/project.json
+++ b/libs/rudder-integration-firebase-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-firebase-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-firebase-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-firebase-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-firebase-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-firebase-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-firebase-react-native.podspec",
+            "input": "libs/rudder-integration-firebase-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-firebase-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-firebase-react-native/rudder-integration-firebase-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-firebase-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-firebase-react-native",
             "output": "."
           },
           {
@@ -48,9 +48,9 @@
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-firebase-react-native/src",
-            "input": ".",
-            "output": "."
+            "glob": "**/*",
+            "input": "libs/rudder-integration-firebase-react-native/src",
+            "output": "src"
           }
         ],
         "updateBuildableProjectDepsInPackageJson": true,

--- a/libs/rudder-integration-moengage-react-native/project.json
+++ b/libs/rudder-integration-moengage-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-moengage-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-moengage-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-moengage-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-moengage-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-moengage-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-moengage-react-native.podspec",
+            "input": "libs/rudder-integration-moengage-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-moengage-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-moengage-react-native/rudder-integration-moengage-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-moengage-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-moengage-react-native",
             "output": "."
           },
           {

--- a/libs/rudder-integration-singular-react-native/project.json
+++ b/libs/rudder-integration-singular-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-singular-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-singular-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-singular-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-singular-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-singular-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-singular-react-native.podspec",
+            "input": "libs/rudder-integration-singular-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-singular-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-singular-react-native/rudder-integration-singular-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-singular-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-singular-react-native",
             "output": "."
           },
           {

--- a/libs/rudder-integration-sprig-react-native/project.json
+++ b/libs/rudder-integration-sprig-react-native/project.json
@@ -18,28 +18,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/rudder-integration-sprig-react-native/README.md",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/rudder-integration-sprig-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-sprig-react-native/android",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/rudder-integration-sprig-react-native/android",
+            "output": "android"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/rudder-integration-sprig-react-native/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "rudder-integration-sprig-react-native.podspec",
+            "input": "libs/rudder-integration-sprig-react-native",
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-sprig-react-native/ios",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-sprig-react-native/rudder-integration-sprig-react-native.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/rudder-integration-sprig-react-native/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/rudder-integration-sprig-react-native",
             "output": "."
           },
           {
@@ -48,9 +48,9 @@
             "output": "."
           },
           {
-            "glob": "libs/rudder-integration-sprig-react-native/src",
-            "input": ".",
-            "output": "."
+            "glob": "**/*",
+            "input": "libs/rudder-integration-sprig-react-native/src",
+            "output": "src"
           }
         ],
         "updateBuildableProjectDepsInPackageJson": true,

--- a/libs/sdk/project.json
+++ b/libs/sdk/project.json
@@ -24,28 +24,28 @@
         "babelUpwardRootMode": true,
         "assets": [
           {
-            "glob": "libs/sdk/ios",
-            "input": ".",
+            "glob": "**/*",
+            "input": "libs/sdk/ios",
+            "output": "ios"
+          },
+          {
+            "glob": "**/*",
+            "input": "libs/sdk/android",
+            "output": "android"
+          },
+          {
+            "glob": "RNRudderSdk.podspec",
+            "input": "libs/sdk",
             "output": "."
           },
           {
-            "glob": "libs/sdk/android",
-            "input": ".",
+            "glob": "README.md",
+            "input": "libs/sdk",
             "output": "."
           },
           {
-            "glob": "libs/sdk/RNRudderSdk.podspec",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/sdk/README.md",
-            "input": ".",
-            "output": "."
-          },
-          {
-            "glob": "libs/sdk/CHANGELOG.md",
-            "input": ".",
+            "glob": "CHANGELOG.md",
+            "input": "libs/sdk",
             "output": "."
           },
           {
@@ -54,9 +54,9 @@
             "output": "."
           },
           {
-            "glob": "libs/sdk/src",
-            "input": ".",
-            "output": "."
+            "glob": "**/*",
+            "input": "libs/sdk/src",
+            "output": "src"
           }
         ],
         "updateBuildableProjectDepsInPackageJson": true,


### PR DESCRIPTION
## Summary

The Nx 20.8.4 → 22.7.8 upgrade (#687) silently broke asset copying in every library build: `@nx/rollup` 22 no longer expands directory-style asset globs (`"glob": "libs/sdk/ios"`), so `android/`, `ios/`, and the raw `src/*.ts` files stopped being copied into `dist/libs/*`. The SDK tarball dropped from 186 kB (published 3.1.1) to 9 kB — the next npm release would have shipped packages with no native code, breaking autolinking and RN codegen for every consumer. This PR fixes the asset configuration across all 12 publishable packages so the packaged output matches the last good releases.

## Changes

- **All 12 `libs/*/project.json` files** — rewrote the `assets` entries to the canonical Nx 22 form: directory copies use `{"glob": "**/*", "input": "<lib>/ios|android|src", "output": "ios|android|src"}`, and file copies use `{"glob": "<file>", "input": "<lib>", "output": "."}`.
- **`.nxignore`** — anchored `README.md` → `/README.md` and `CHANGELOG.md` → `/CHANGELOG.md`. Nx 22's `CopyAssetsHandler` honors `.nxignore`, and the unanchored entries matched per-package README/CHANGELOG files at any depth, dropping them from the packaged output.
- **`libs/plugins/rudder-plugin-db-encryption-react-native/project.json`** — added `"useLegacyTypescriptPlugin": true`. With the raw `.ts` source restored to `dist/libs/sdk`, Nx 22's new `@rollup/plugin-typescript` walks the SDK's dist source and fails with a `rootDir` violation (TS6059); `rollup-plugin-typescript2` is the plugin Nx 20 used, so this keeps behavior identical to previous releases while retaining type checking.

## Testing

- Clean rebuild (`nx run-many --target=build --skip-nx-cache`) — all 12 packages' `dist` now contain `ios/`, `android/`, `README.md`, `CHANGELOG.md`, and the podspec; the SDK additionally contains raw `src/*.ts` (required by RN codegen via `codegenConfig.jsSrcsDir`).
- `nx deploy <pkg> --dry-run` for all 12 packages — every tarball packs successfully; the SDK packs 42.4 kB (vs 9.1 kB before the fix).
- File-list diff of the local SDK pack vs the published 3.1.1 tarball — identical except: `index.esm.d.ts` renamed to `index.d.ts` (Nx 22 rename, `package.json` `types` field is consistent), two test files added in this release cycle (#685), and per-file `src/*.d.ts` now emitted by Nx 22 alongside the source (harmless — TS resolution still picks the `.ts` source as before).
- Consumer typecheck (issue #620 regression guard): packed the SDK tarball, installed it in a fresh project with `react-native@0.83.9`, ran strict `tsc` with no `skipLibCheck` — passes.
- `nx run-many` lint / type-check / test all pass on the branch.

## Screenshots

No UI changes in this PR.

## Notes

- No breaking changes or migration steps required; this restores the packaged output to what Nx 20 produced.
- This gates the pending 3.2.0 release PR: merge this first, let release-please rebase, and re-verify with `nx deploy rudder-sdk-react-native --dry-run` (~42 kB expected) before cutting the release.
- Heads-up when editing any `project.json`: the Nx daemon caches project configuration aggressively — run `npx nx reset` if a config change appears to be ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore patterns so root-level changelog and README files are handled consistently.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->