### PR TITLE
ci: fix build configuration and sonar credential handling

### DIFF
--- a/.github/workflows/build-android-checks.yml
+++ b/.github/workflows/build-android-checks.yml
@@ -43,13 +43,8 @@ jobs:
         run: |
           npm run setup:ci
 
-      - name: Add .env file
-        run: |
-          pwd
-          echo '${{secrets.DOT_ENV}}' > apps/example/.env
-          echo "$( < apps/example/.env)"
-          cd apps/example/
-          ls -li
+      - name: Configure example for build verification
+        run: cp apps/example/.env.sample apps/example/.env
 
       - name: Bundle apps
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,8 @@ jobs:
         run: |
           npm run setup:ci
 
-      - name: Setup .env file
-        run: |
-          cat <<EOF > apps/example/.env
-            TEST_WRITE_KEY=${{ secrets.TEST_WRITE_KEY }}
-            TEST_DATAPLANE_URL=${{ secrets.TEST_DATAPLANE_URL }}
-           EOF
+      - name: Configure example for unit tests
+        run: cp apps/example/.env.sample apps/example/.env
 
       - name: Execute linting tests
         run: |
@@ -66,7 +62,13 @@ jobs:
         run: |
           npm run test:ci
 
+      # Fork and Dependabot PRs do not receive repository secrets. Lint and tests
+      # above still run; authenticated analysis also runs after merge to master.
       - name: SonarQube Scan
+        if: >-
+          github.actor != 'dependabot[bot]' &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,7 @@ jobs:
         run: |
           npm run test:ci
 
-      # Fork PRs do not receive repository secrets. Dependabot uses its own
-      # configured SONAR_TOKEN and remains eligible for analysis.
+      # Fork PRs do not receive the SONAR_TOKEN secret required for analysis.
       - name: SonarQube Scan
         if: >-
           github.event_name != 'pull_request' ||

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,13 +62,12 @@ jobs:
         run: |
           npm run test:ci
 
-      # Fork and Dependabot PRs do not receive repository secrets. Lint and tests
-      # above still run; authenticated analysis also runs after merge to master.
+      # Fork PRs do not receive repository secrets. Dependabot uses its own
+      # configured SONAR_TOKEN and remains eligible for analysis.
       - name: SonarQube Scan
         if: >-
-          github.actor != 'dependabot[bot]' &&
-          (github.event_name != 'pull_request' ||
-           github.event.pull_request.head.repo.full_name == github.repository)
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Android build verification depends on secret-backed example configuration, so missing credentials leave BuildConfig.MOENGAGE_ANDROID_APP_ID undefined. Use the checked-in empty example configuration for Android and unit tests. Keep Sonar analysis on eligible runs and master pushes, and skip its authenticated step only for fork PRs. Dependabot PRs retain Sonar using the repository’s configured Dependabot SONAR_TOKEN. Lint, tests and build steps remain enabled.

This PR changes only two workflow files. Dependency audit remediation is isolated in [PR #702](https://github.com/rudderlabs/rudder-sdk-react-native/pull/702).

Validation: actionlint and formatting pass. The Sonar condition was checked for fork PRs (skip), same-repository PRs (run), Dependabot PRs (run), master pushes (run) and manual runs (run). The repository has a Dependabot SONAR_TOKEN, and an existing [Dependabot Sonar run succeeded](https://github.com/rudderlabs/rudder-sdk-react-native/actions/runs/33049479953/job/98441196065).

Earlier local and GitHub build/test evidence is recorded in SDK-5447. CI is rerunning for the narrower condition in e1317d2; previous results are historical evidence. The existing audit findings remain on this branch until #702 merges and this branch is updated with master.

Tracking and evidence: [SDK-5447](https://linear.app/rudderstack/issue/SDK-5447). The Sonar policy inconsistency across SDK repositories is recorded in [SDK-5446](https://linear.app/rudderstack/issue/SDK-5446).

Investigation context: these issues surfaced during [PR #696](https://github.com/rudderlabs/rudder-sdk-react-native/pull/696), documented in [SDK-5443](https://linear.app/rudderstack/issue/SDK-5443). Its organization-injected zizmor trust requirement remains separate.
